### PR TITLE
Add a cargo config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /build/
 /doc/
 /Makefile
+/target

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+
+name = "phf_mac"
+authors = ["Steven Fackler <sfackler@gmail.com>"]
+version = "0.0.1"
+
+[[lib]]
+
+name = "phf_mac"
+path = "src/phf_mac.rs"
+crate_type = ["dylib"]
+
+[dependencies.phf]
+
+path = "phf_cargo_hack"

--- a/phf_cargo_hack/Cargo.toml
+++ b/phf_cargo_hack/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+
+name = "phf"
+authors = ["Steven Fackler <sfackler@gmail.com>"]
+version = "0.0.1"
+
+[[lib]]
+
+name = "phf"
+path = "../src/phf.rs"


### PR DESCRIPTION
For now it's a bit wonky to get around the two crates here (needs a second `Cargo.toml`), but you can now depend on the git repo for either `phf` or `phf_mac`
