### PR TITLE
HashMap/HashSet moved

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -5,7 +5,7 @@ extern crate phf_mac;
 extern crate phf;
 
 mod map {
-    use std::collections::{HashMap, HashSet};
+    use std::collections::hashmap::{HashMap, HashSet};
     use phf::PhfMap;
 
     #[allow(dead_code)]


### PR DESCRIPTION
http://doc.rust-lang.org/master/std/collections/hashmap/struct.HashMap.html
http://doc.rust-lang.org/master/std/collections/hashmap/struct.HashSet.html

(This wasn't caught before due to test.rs being compiled on `make check` calls)
