### PR TITLE
Update Cargo.toml to the new `plugin = true` flag

### DIFF
--- a/phf_mac/Cargo.toml
+++ b/phf_mac/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.0.0"
 
 name = "phf_mac"
 path = "src/lib.rs"
-crate_type = ["dylib"]
+plugin = true
 
 [dependencies.phf]
 


### PR DESCRIPTION
This flag properly communicates that the crate is a plugin which implies that it needs to be built for the host architecture and that it needs to be built as a dynamic library.
