### PR TITLE
Optimise bucket placement.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Rust-PHF is a library to generate efficient lookup tables at compile time using
 
 It currently uses the
 [CHD algorithm](http://cmph.sourceforge.net/papers/esa09.pdf) and can generate
-a 10,000 entry map in roughly .25 seconds.
+a 100,000 entry map in roughly .4 seconds.
 
 Documentation is available at http://www.rust-ci.org/sfackler/rust-phf/doc/phf/.
 


### PR DESCRIPTION
Use a "generation vector" instead of a hashmap for storing the elements
of the bucket currently being placed. This gives a 2x speed-up
e.g. creating a phf_set out of my 99171-line /usr/share/dict/words took
1 second previously and now takes 0.4-0.5.
