### PR TITLE
Enable slicing syntax

### DIFF
--- a/phf/src/lib.rs
+++ b/phf/src/lib.rs
@@ -4,7 +4,7 @@
 //! literals, or any of the fixed-size integral types.
 #![doc(html_root_url="http://www.rust-ci.org/sfackler")]
 #![warn(missing_doc)]
-#![feature(macro_rules)]
+#![feature(macro_rules, slicing_syntax)]
 
 use std::fmt;
 use std::iter;

--- a/phf_mac/src/lib.rs
+++ b/phf_mac/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! See the documentation for the `phf` crate for more details.
 #![doc(html_root_url="http://sfackler.github.io/rust-phf/doc")]
-#![feature(plugin_registrar, quote, default_type_params, macro_rules)]
+#![feature(plugin_registrar, quote, default_type_params, macro_rules, slicing_syntax)]
 
 extern crate rand;
 extern crate syntax;


### PR DESCRIPTION
To get rid of:

```
error: slicing syntax is experimental
note: add #![feature(slicing_syntax)] to the crate attributes to enable
```
