### PR TITLE
Add required slicing_syntax feature gate.

### DIFF
--- a/phf_mac/src/lib.rs
+++ b/phf_mac/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! See the documentation for the `phf` crate for more details.
 #![doc(html_root_url="http://sfackler.github.io/rust-phf/doc")]
-#![feature(plugin_registrar, quote, default_type_params, macro_rules)]
+#![feature(plugin_registrar, quote, default_type_params, macro_rules, slicing_syntax)]
 
 extern crate rand;
 extern crate syntax;


### PR DESCRIPTION
Fixes a broken build on the latest rust.
