### PR TITLE
Use cargoified time crate

### DIFF
--- a/phf_mac/Cargo.toml
+++ b/phf_mac/Cargo.toml
@@ -13,3 +13,6 @@ test = false
 
 [dependencies.xxhash]
 git = "https://github.com/Jurily/rust-xxhash"
+
+[dependencies.time]
+git = "https://github.com/rust-lang/time"


### PR DESCRIPTION
The one distributed with rustc is now depreciated.
