### PR TITLE
Add rust-lang/time as dependency for phf_mac

### DIFF
--- a/phf_mac/Cargo.toml
+++ b/phf_mac/Cargo.toml
@@ -13,3 +13,6 @@ test = false
 
 [dependencies.xxhash]
 git = "https://github.com/Jurily/rust-xxhash"
+
+[dependencies.time]
+git = "https://github.com/rust-lang/time"


### PR DESCRIPTION
Update build to point to new libtime which has been split into it's own project.
