### PR TITLE
add support for [u8, ..N] keys

### DIFF
--- a/phf/tests/test.rs
+++ b/phf/tests/test.rs
@@ -144,6 +144,24 @@ mod map {
     )
 
     #[test]
+    fn test_array_vals() {
+        static MAP: phf::Map<&'static str, [u8, ..3]> = phf_map!(
+            "a" => [0u8, 1, 2],
+        );
+        assert_eq!(Some(&[0u8, 1, 2]), MAP.get(&("a")));
+    }
+
+    #[test]
+    fn test_array_keys() {
+        static MAP: phf::Map<[u8, ..2], int> = phf_map!(
+            [0u8, 1] => 0,
+            [2, 3u8] => 1,
+            [4, 5] => 2,
+        );
+        assert_eq!(Some(&0), MAP.get(&[0u8, 1u8]));
+    }
+
+    #[test]
     fn test_binary_keys() {
         test_key_type!(&'static [u8], b"hello" => 0, b"world" => 1);
     }

--- a/phf_shared/src/lib.rs
+++ b/phf_shared/src/lib.rs
@@ -76,3 +76,47 @@ sip_impl!(u64)
 sip_impl!(i64)
 sip_impl!(char)
 sip_impl!(bool)
+
+macro_rules! array_impl(
+    ($t:ty, $n:expr) => (
+        impl PhfHash for [$t, ..$n] {
+            #[inline]
+            fn phf_hash(&self, seed: u64) -> (u32, u32, u32) {
+                split(xxhash::oneshot(self, seed))
+            }
+        }
+    )
+)
+
+array_impl!(u8, 1)
+array_impl!(u8, 2)
+array_impl!(u8, 3)
+array_impl!(u8, 4)
+array_impl!(u8, 5)
+array_impl!(u8, 6)
+array_impl!(u8, 7)
+array_impl!(u8, 8)
+array_impl!(u8, 9)
+array_impl!(u8, 10)
+array_impl!(u8, 11)
+array_impl!(u8, 12)
+array_impl!(u8, 13)
+array_impl!(u8, 14)
+array_impl!(u8, 15)
+array_impl!(u8, 16)
+array_impl!(u8, 17)
+array_impl!(u8, 18)
+array_impl!(u8, 19)
+array_impl!(u8, 20)
+array_impl!(u8, 21)
+array_impl!(u8, 22)
+array_impl!(u8, 23)
+array_impl!(u8, 24)
+array_impl!(u8, 25)
+array_impl!(u8, 26)
+array_impl!(u8, 27)
+array_impl!(u8, 28)
+array_impl!(u8, 29)
+array_impl!(u8, 30)
+array_impl!(u8, 31)
+array_impl!(u8, 32)


### PR DESCRIPTION
This implements PhfHash for [u8, ..1] up to [u8, ..32]. I'd prefer to support [T, ..N] for any T: PhfHash and integral N, but given the lack of variadic generics that isn't possible. It might be able to rework this to have the T: PhfHash part work, though. That said, it would be more work and it isn't necessarily obvious that hashing more complex structures would be very useful, while the need for various sizes of immediate byte literals is more likely to occur in practice.

I also added a test to check to make sure that array values work as output values for hashing--that seems to work nicely even without the other changes, but I figure the test can't hurt.
