### PR TITLE
Added FmtConst impl for String and Vec<Primitive>

### DIFF
--- a/phf_codegen/src/lib.rs
+++ b/phf_codegen/src/lib.rs
@@ -133,7 +133,7 @@
 //! ```
 #![doc(html_root_url = "https://docs.rs/phf_codegen/0.7")]
 
-use phf_shared::{PhfHash, FmtConst};
+use phf_shared::{FmtConst, PhfHash};
 use std::collections::HashSet;
 use std::fmt;
 use std::hash::Hash;
@@ -221,45 +221,54 @@ pub struct DisplayMap<'a, K> {
     state: HashState,
     keys: &'a [K],
     values: &'a [String],
-
 }
 
 impl<'a, K: FmtConst + 'a> fmt::Display for DisplayMap<'a, K> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // funky formatting here for nice output
-        write!(f,
-               "{}::Map {{
+        write!(
+            f,
+            "{}::Map {{
     key: {:?},
     disps: {}::Slice::Static(&[",
-               self.path, self.state.key, self.path)?;
+            self.path, self.state.key, self.path
+        )?;
 
         // write map displacements
         for &(d1, d2) in &self.state.disps {
-            write!(f,
-                   "
+            write!(
+                f,
+                "
         ({}, {}),",
-                   d1,
-                   d2)?;
+                d1, d2
+            )?;
         }
 
-        write!(f,
-               "
+        write!(
+            f,
+            "
     ]),
-    entries: {}::Slice::Static(&[", self.path)?;
+    entries: {}::Slice::Static(&[",
+            self.path
+        )?;
 
         // write map entries
         for &idx in &self.state.map {
-            write!(f,
-                   "
+            write!(
+                f,
+                "
         ({}, {}),",
-                   Delegate(&self.keys[idx]),
-                   &self.values[idx])?;
+                Delegate(&self.keys[idx]),
+                &self.values[idx]
+            )?;
         }
 
-        write!(f,
-               "
+        write!(
+            f,
+            "
     ]),
-}}")
+}}"
+        )
     }
 }
 
@@ -271,9 +280,7 @@ pub struct Set<T> {
 impl<T: Hash + PhfHash + Eq + FmtConst> Set<T> {
     /// Constructs a new `phf::Set` builder.
     pub fn new() -> Set<T> {
-        Set {
-            map: Map::new(),
-        }
+        Set { map: Map::new() }
     }
 
     /// Set the path to the `phf` crate from the global namespace
@@ -296,7 +303,7 @@ impl<T: Hash + PhfHash + Eq + FmtConst> Set<T> {
     /// Panics if there are any duplicate keys.
     pub fn build(&self) -> DisplaySet<T> {
         DisplaySet {
-            inner: self.map.build()
+            inner: self.map.build(),
         }
     }
 }

--- a/phf_shared/src/lib.rs
+++ b/phf_shared/src/lib.rs
@@ -111,6 +111,19 @@ delegate_debug!(u128);
 delegate_debug!(i128);
 delegate_debug!(bool);
 
+delegate_debug!(String);
+delegate_debug!(Vec<u8>);
+delegate_debug!(Vec<i8>);
+delegate_debug!(Vec<u16>);
+delegate_debug!(Vec<i16>);
+delegate_debug!(Vec<u32>);
+delegate_debug!(Vec<i32>);
+delegate_debug!(Vec<u64>);
+delegate_debug!(Vec<i64>);
+delegate_debug!(Vec<u128>);
+delegate_debug!(Vec<i128>);
+delegate_debug!(Vec<bool>);
+
 #[cfg(feature = "std")]
 impl PhfHash for String {
     #[inline]


### PR DESCRIPTION
This allows the user to user owned types for dynamic code generation.

Here is a example where this is required:
```rust
let mut bldr = phf_codegen::Map::new();
// In this case symbol_ids is a HashMap<String, u32> whose content is only known
// at runtime.
for (symbol, id) in symbol_ids {
    bldr.entry(symbol, &id.to_string());
}
let display = bldr.build().to_string();
```

Previously the user would have to leak the String to get a &'static str.

I also ran rustfmt, which explains some of the diff.