### PR TITLE
Add support for uncased

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
       fail-fast: false
       matrix:
         # MSRV and nightly
-        version: [1.40.0, nightly]
+        version: [1.46.0, nightly]
     steps:
       - uses: actions/checkout@v2
-        
+
       - name: Set toolchain
         run: |
           rustup set profile minimal

--- a/phf/Cargo.toml
+++ b/phf/Cargo.toml
@@ -15,6 +15,7 @@ test = false
 [features]
 default = ["std"]
 std = ["phf_shared/std"]
+uncased = ["phf_shared/uncased"]
 unicase = ["phf_shared/unicase"]
 macros = [
 	"phf_macros",

--- a/phf_codegen/test/Cargo.toml
+++ b/phf_codegen/test/Cargo.toml
@@ -6,9 +6,11 @@ build = "build.rs"
 edition = "2018"
 
 [dependencies]
-phf = { version = "0.8", features = ["unicase"] }
+phf = { version = "0.8", features = ["uncased", "unicase"] }
+uncased = { version = "0.9.6", default-features = false }
 unicase = "2.4.0"
 
 [build-dependencies]
 phf_codegen = "0.8"
 unicase = "2.4.0"
+uncased = { version = "0.9.6", default-features = false }

--- a/phf_codegen/test/build.rs
+++ b/phf_codegen/test/build.rs
@@ -6,6 +6,7 @@ use std::fs::File;
 use std::io::{self, BufWriter, Write};
 use std::path::Path;
 
+use uncased::UncasedStr;
 use unicase::UniCase;
 
 fn main() -> io::Result<()> {
@@ -68,6 +69,15 @@ fn main() -> io::Result<()> {
         phf_codegen::Map::new()
             .entry(UniCase::new("abc"), "\"a\"")
             .entry(UniCase::new("DEF"), "\"b\"")
+            .build()
+    )?;
+
+    write!(
+        &mut file,
+        "static UNCASED_MAP: ::phf::Map<&'static ::uncased::UncasedStr, &'static str> = \n{};",
+        phf_codegen::Map::new()
+            .entry(UncasedStr::new("abc"), "\"a\"")
+            .entry(UncasedStr::new("DEF"), "\"b\"")
             .build()
     )?;
 

--- a/phf_codegen/test/src/lib.rs
+++ b/phf_codegen/test/src/lib.rs
@@ -1,5 +1,6 @@
 #[cfg(test)]
 mod test {
+    use uncased::UncasedStr;
     use unicase::UniCase;
 
     include!(concat!(env!("OUT_DIR"), "/codegen.rs"));
@@ -59,6 +60,14 @@ mod test {
         assert_eq!("a", UNICASE_MAP[&UniCase::new(&*local_str_1)]);
         assert_eq!("a", UNICASE_MAP[&UniCase::new(&*local_str_2)]);
         assert_eq!("b", UNICASE_MAP[&UniCase::new(&*local_str_3)]);
+    }
+
+    #[test]
+    fn uncased_map() {
+        assert_eq!("a", UNCASED_MAP[&UncasedStr::new("AbC")]);
+        assert_eq!("a", UNCASED_MAP[&UncasedStr::new("abc")]);
+        assert_eq!("b", UNCASED_MAP[&UncasedStr::new("DEf")]);
+        assert!(!UNCASED_MAP.contains_key(&UncasedStr::new("XyZ")));
     }
 
     #[test]

--- a/phf_shared/Cargo.toml
+++ b/phf_shared/Cargo.toml
@@ -19,3 +19,4 @@ std = []
 [dependencies]
 siphasher = "0.3"
 unicase = { version = "2.4.0", optional = true }
+uncased = { version = "0.9.6", optional = true, default-features = false }


### PR DESCRIPTION
I suspect the `unsafe` in this PR may make this unmergeable, but figured I'd throw up anyway, because the current support for `UniCase` is sadly pretty useless, as far as I can tell. Details below, but basically AFAICT you can only perform lookups in a `UniCase` map if you have a static string literal.

----

uncased is an ASCII-only case insensitive comparison library like
UniCase, but it has better support for being used in a map.

Specifically, UniCase does not support the Borrow trait (see
seanmonstar/unicase#22), so the type

    phf::Map<UniCase<&'static str>, _>

only supports lookups with static string literals, which has limited
usefulness.

By contrast, the the equivalent uncased construction

    phf::Map<&'static Uncased, _>

*does* support lookups with non-static strings.