### PR TITLE
Only trigger benchmarks when added a label

### DIFF
--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -1,9 +1,11 @@
 name: Bench
-# FIXME: Run only when adding `benchmarks` label?
-on: [pull_request]
+on:
+  pull_request:
+    types: [labeled]
 
 jobs:
   bench_between_master_and_pr:
+    if: ${{ github.event.label.name == 'run-benchmarks' }}
     name: Bench
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The benchmarks take about 1 hour currently, it should make sense to limit the trigger event only when adding the `run-benchmarks` label.