### PR TITLE
Rename `unicase_support` to `unicase`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: phf_macros UI test
         if: matrix.version == '1.40.0'
         working-directory: phf_macros
-        run: cargo test --features=unicase_support -- --ignored --test-threads=1
+        run: cargo test --features=unicase -- --ignored --test-threads=1
 
       - name: phf_codegen test
         run: cargo test -p phf_codegen_test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ## Unreleased
 
-* Our MSRV is now 1.40.0 (because of dependencies)
+* Our MSRV is now 1.46.0 (because of dependencies)
 * `rand` dependency has been upgraded to 0.8
 * Fix some crates' build on `no_std`
-* Restore the `unicase_support` feature for `phf_macros`
+* Restore the `unicase` feature for `phf_macros`
 * Allow using the owned `String` type for `phf` dynamic code generation
 * Add back `OrderedMap` and `OrderedSet`
 * (**breaking change**) Use `PhfBorrow` trait instead of `std::borrow::Borrow`

--- a/phf/Cargo.toml
+++ b/phf/Cargo.toml
@@ -18,8 +18,8 @@ std = ["phf_shared/std"]
 uncased = ["phf_shared/uncased"]
 unicase = ["phf_shared/unicase"]
 macros = [
-	"phf_macros",
-	"proc-macro-hack",
+    "phf_macros",
+    "proc-macro-hack",
 ]
 
 [dependencies]
@@ -29,5 +29,4 @@ proc-macro-hack = { version = "0.5.4", optional = true }
 phf_macros = { version = "0.8.0", optional = true }
 
 [package.metadata.docs.rs]
-features = ["macros", ]
-
+features = ["macros"]

--- a/phf_macros/Cargo.toml
+++ b/phf_macros/Cargo.toml
@@ -11,14 +11,14 @@ repository = "https://github.com/sfackler/rust-phf"
 proc-macro = true
 
 [features]
-unicase_support = ["unicase", "phf_shared/unicase"]
+unicase = ["unicase_", "phf_shared/unicase"]
 
 [dependencies]
 syn = { version = "1", features = ["full"] }
 quote = "1"
 proc-macro2 = "1"
 proc-macro-hack = "0.5.4"
-unicase = { version = "2.4.0", optional = true }
+unicase_ = { package = "unicase", version = "2.4.0", optional = true }
 
 phf_generator = "0.8.0"
 phf_shared = { version = "0.8.0", default-features = false }
@@ -26,4 +26,3 @@ phf_shared = { version = "0.8.0", default-features = false }
 [dev-dependencies]
 trybuild = "1.0"
 phf = { version = "0.8", features = ["macros", "unicase"] }
-unicase = "2.4.0"

--- a/phf_macros/src/lib.rs
+++ b/phf_macros/src/lib.rs
@@ -8,11 +8,11 @@ use std::collections::HashSet;
 use std::hash::Hasher;
 use syn::parse::{self, Parse, ParseStream};
 use syn::punctuated::Punctuated;
-#[cfg(feature = "unicase_support")]
+#[cfg(feature = "unicase")]
 use syn::ExprLit;
 use syn::{parse_macro_input, Error, Expr, Lit, Token, UnOp};
-#[cfg(feature = "unicase_support")]
-use unicase::UniCase;
+#[cfg(feature = "unicase")]
+use unicase_::UniCase;
 
 #[derive(Hash, PartialEq, Eq, Clone)]
 enum ParsedKey {
@@ -30,7 +30,7 @@ enum ParsedKey {
     U64(u64),
     U128(u128),
     Bool(bool),
-    #[cfg(feature = "unicase_support")]
+    #[cfg(feature = "unicase")]
     UniCase(UniCase<String>),
 }
 
@@ -54,7 +54,7 @@ impl PhfHash for ParsedKey {
             ParsedKey::U64(s) => s.phf_hash(state),
             ParsedKey::U128(s) => s.phf_hash(state),
             ParsedKey::Bool(s) => s.phf_hash(state),
-            #[cfg(feature = "unicase_support")]
+            #[cfg(feature = "unicase")]
             ParsedKey::UniCase(s) => s.phf_hash(state),
         }
     }
@@ -124,7 +124,7 @@ impl ParsedKey {
                 }
             }
             Expr::Group(group) => ParsedKey::from_expr(&group.expr),
-            #[cfg(feature = "unicase_support")]
+            #[cfg(feature = "unicase")]
             Expr::Call(call) => if let Expr::Path(ep) = call.func.as_ref() {
                 let segments = &mut ep.path.segments.iter().rev();
                 let last = &segments.next()?.ident;

--- a/phf_macros/tests/test.rs
+++ b/phf_macros/tests/test.rs
@@ -237,10 +237,10 @@ mod map {
         }
     }
 
-    #[cfg(feature = "unicase_support")]
+    #[cfg(feature = "unicase")]
     #[test]
     fn test_unicase() {
-        use unicase::UniCase;
+        use unicase_::UniCase;
         static MAP: phf::Map<UniCase<&'static str>, isize> = phf_map!(
             UniCase::ascii("FOO") => 10,
             UniCase::unicode("Bar") => 11,


### PR DESCRIPTION
As suggested in the previous PR, this renames the phf-macro's feature to just `unicase` for consistency.