### PR TITLE
Fix the release failure

### DIFF
--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -3,7 +3,7 @@
 - Update the version number and all the references to it
 - Make a new release on GitHub (i.e. add a new git tag)
 - Publish crates in order:
-  1. `puf_shared`
+  1. `phf_shared`
   2. `phf_generator`
   3. `phf_codegen`
   4. `phf_macros`

--- a/phf_macros/Cargo.toml
+++ b/phf_macros/Cargo.toml
@@ -27,5 +27,5 @@ phf_shared = { version = "0.9.0", default-features = false }
 
 [dev-dependencies]
 trybuild = "1.0"
-phf = { version = "0.8", features = ["macros", "unicase"] }
+phf = { version = "*", features = ["macros", "unicase"] }
 unicase_ = { package = "unicase", version = "2.4.0" }


### PR DESCRIPTION
There is a cyclic dependency chain between phf and phf_macros and I had to downgrade the `phf` version when releasing. This PR should resolve it by specifying its version as `*`.