### PR TITLE
Remove `Slice` and upgrade `len` and `is_empty` to const-fns

### DIFF
--- a/phf/src/lib.rs
+++ b/phf/src/lib.rs
@@ -138,6 +138,18 @@ pub enum Slice<T: 'static> {
     Dynamic(Vec<T>),
 }
 
+// NOTE: we need this because `Deref::deref` is not a `const-fn` so we can't use
+// `len` as written in `Map`/`Set`/`OrderedMap`/`OrderedSet` since it involves
+// an implicit indirection
+#[cfg(not(feature = "std"))]
+impl<T> Slice<T> {
+    pub(crate) const fn len(&self) -> usize {
+        match self {
+            Self::Static(slice) => slice.len(),
+        }
+    }
+}
+
 impl<T> Deref for Slice<T> {
     type Target = [T];
 

--- a/phf/src/lib.rs
+++ b/phf/src/lib.rs
@@ -110,8 +110,6 @@ pub use phf_macros::phf_set;
 #[proc_macro_hack::proc_macro_hack]
 pub use phf_macros::phf_ordered_set;
 
-use core::ops::Deref;
-
 #[doc(inline)]
 pub use self::map::Map;
 #[doc(inline)]
@@ -126,38 +124,3 @@ pub mod map;
 pub mod ordered_map;
 pub mod ordered_set;
 pub mod set;
-
-// WARNING: this is not considered part of phf's public API and is subject to
-// change at any time.
-//
-// Basically Cow, but with the Owned version conditionally compiled.
-#[doc(hidden)]
-pub enum Slice<T: 'static> {
-    Static(&'static [T]),
-    #[cfg(feature = "std")]
-    Dynamic(Vec<T>),
-}
-
-// NOTE: we need this because `Deref::deref` is not a `const-fn` so we can't use
-// `len` as written in `Map`/`Set`/`OrderedMap`/`OrderedSet` since it involves
-// an implicit indirection
-#[cfg(not(feature = "std"))]
-impl<T> Slice<T> {
-    pub(crate) const fn len(&self) -> usize {
-        match self {
-            Self::Static(slice) => slice.len(),
-        }
-    }
-}
-
-impl<T> Deref for Slice<T> {
-    type Target = [T];
-
-    fn deref(&self) -> &[T] {
-        match *self {
-            Slice::Static(t) => t,
-            #[cfg(feature = "std")]
-            Slice::Dynamic(ref t) => t,
-        }
-    }
-}

--- a/phf/src/map.rs
+++ b/phf/src/map.rs
@@ -46,12 +46,26 @@ where
 
 impl<K, V> Map<K, V> {
     /// Returns true if the `Map` is empty.
+    #[cfg(feature = "std")]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
+    /// Returns true if the `Map` is empty.
+    #[cfg(not(feature = "std"))]
+    pub const fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     /// Returns the number of entries in the `Map`.
+    #[cfg(feature = "std")]
     pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Returns the number of entries in the `Map`.
+    #[cfg(not(feature = "std"))]
+    pub const fn len(&self) -> usize {
         self.entries.len()
     }
 

--- a/phf/src/map.rs
+++ b/phf/src/map.rs
@@ -1,5 +1,4 @@
 //! An immutable map constructed at compile time.
-use crate::Slice;
 use core::fmt;
 use core::iter::IntoIterator;
 use core::ops::Index;
@@ -17,9 +16,9 @@ pub struct Map<K: 'static, V: 'static> {
     #[doc(hidden)]
     pub key: HashKey,
     #[doc(hidden)]
-    pub disps: Slice<(u32, u32)>,
+    pub disps: &'static [(u32, u32)],
     #[doc(hidden)]
-    pub entries: Slice<(K, V)>,
+    pub entries: &'static [(K, V)],
 }
 
 impl<K, V> fmt::Debug for Map<K, V>
@@ -45,28 +44,16 @@ where
 }
 
 impl<K, V> Map<K, V> {
-    /// Returns true if the `Map` is empty.
-    #[cfg(feature = "std")]
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
-    /// Returns true if the `Map` is empty.
-    #[cfg(not(feature = "std"))]
-    pub const fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
     /// Returns the number of entries in the `Map`.
-    #[cfg(feature = "std")]
-    pub fn len(&self) -> usize {
-        self.entries.len()
-    }
-
-    /// Returns the number of entries in the `Map`.
-    #[cfg(not(feature = "std"))]
+    #[inline]
     pub const fn len(&self) -> usize {
         self.entries.len()
+    }
+
+    /// Returns true if the `Map` is empty.
+    #[inline]
+    pub const fn is_empty(&self) -> bool {
+        self.len() == 0
     }
 
     /// Determines if `key` is in the `Map`.
@@ -105,7 +92,7 @@ impl<K, V> Map<K, V> {
         T: Eq + PhfHash,
         K: PhfBorrow<T>,
     {
-        if self.disps.len() == 0 {
+        if self.disps.is_empty() {
             return None;
         } //Prevent panic on empty map
         let hashes = phf_shared::hash(key, &self.key);

--- a/phf/src/ordered_map.rs
+++ b/phf/src/ordered_map.rs
@@ -5,8 +5,6 @@ use core::ops::Index;
 use core::slice;
 use phf_shared::{self, HashKey, PhfBorrow, PhfHash};
 
-use crate::Slice;
-
 /// An order-preserving immutable map constructed at compile time.
 ///
 /// Unlike a `Map`, iteration order is guaranteed to match the definition
@@ -21,11 +19,11 @@ pub struct OrderedMap<K: 'static, V: 'static> {
     #[doc(hidden)]
     pub key: HashKey,
     #[doc(hidden)]
-    pub disps: Slice<(u32, u32)>,
+    pub disps: &'static [(u32, u32)],
     #[doc(hidden)]
-    pub idxs: Slice<usize>,
+    pub idxs: &'static [usize],
     #[doc(hidden)]
-    pub entries: Slice<(K, V)>,
+    pub entries: &'static [(K, V)],
 }
 
 impl<K, V> fmt::Debug for OrderedMap<K, V>
@@ -51,26 +49,14 @@ where
 }
 
 impl<K, V> OrderedMap<K, V> {
-    /// Returns the number of entries in the `Map`.
-    #[cfg(feature = "std")]
-    pub fn len(&self) -> usize {
-        self.entries.len()
-    }
-
-    /// Returns the number of entries in the `Map`.
-    #[cfg(not(feature = "std"))]
+    /// Returns the number of entries in the `OrderedMap`.
+    #[inline]
     pub const fn len(&self) -> usize {
         self.entries.len()
     }
 
-    /// Returns true if the `Map` is empty.
-    #[cfg(feature = "std")]
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
-    /// Returns true if the `Map` is empty.
-    #[cfg(not(feature = "std"))]
+    /// Returns true if the `OrderedMap` is empty.
+    #[inline]
     pub const fn is_empty(&self) -> bool {
         self.len() == 0
     }
@@ -96,7 +82,7 @@ impl<K, V> OrderedMap<K, V> {
         self.get_entry(key).map(|e| e.0)
     }
 
-    /// Determines if `key` is in the `Map`.
+    /// Determines if `key` is in the `OrderedMap`.
     pub fn contains_key<T: ?Sized>(&self, key: &T) -> bool
     where
         T: Eq + PhfHash,
@@ -135,7 +121,7 @@ impl<K, V> OrderedMap<K, V> {
         T: Eq + PhfHash,
         K: PhfBorrow<T>,
     {
-        if self.disps.len() == 0 {
+        if self.disps.is_empty() {
             return None;
         } //Prevent panic on empty map
         let hashes = phf_shared::hash(key, &self.key);

--- a/phf/src/ordered_map.rs
+++ b/phf/src/ordered_map.rs
@@ -52,12 +52,26 @@ where
 
 impl<K, V> OrderedMap<K, V> {
     /// Returns the number of entries in the `Map`.
+    #[cfg(feature = "std")]
     pub fn len(&self) -> usize {
         self.entries.len()
     }
 
+    /// Returns the number of entries in the `Map`.
+    #[cfg(not(feature = "std"))]
+    pub const fn len(&self) -> usize {
+        self.entries.len()
+    }
+
     /// Returns true if the `Map` is empty.
+    #[cfg(feature = "std")]
     pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns true if the `Map` is empty.
+    #[cfg(not(feature = "std"))]
+    pub const fn is_empty(&self) -> bool {
         self.len() == 0
     }
 

--- a/phf/src/ordered_set.rs
+++ b/phf/src/ordered_set.rs
@@ -30,25 +30,13 @@ where
 
 impl<T> OrderedSet<T> {
     /// Returns the number of elements in the `OrderedSet`.
-    #[cfg(feature = "std")]
-    pub fn len(&self) -> usize {
-        self.map.len()
-    }
-
-    /// Returns the number of elements in the `OrderedSet`.
-    #[cfg(not(feature = "std"))]
+    #[inline]
     pub const fn len(&self) -> usize {
         self.map.len()
     }
 
     /// Returns true if the `OrderedSet` contains no elements.
-    #[cfg(feature = "std")]
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
-    /// Returns true if the `OrderedSet` contains no elements.
-    #[cfg(not(feature = "std"))]
+    #[inline]
     pub const fn is_empty(&self) -> bool {
         self.len() == 0
     }
@@ -81,7 +69,7 @@ impl<T> OrderedSet<T> {
         self.map.index(index).map(|(k, &())| k)
     }
 
-    /// Returns true if `value` is in the `Set`.
+    /// Returns true if `value` is in the `OrderedSet`.
     pub fn contains<U: ?Sized>(&self, value: &U) -> bool
     where
         U: Eq + PhfHash,

--- a/phf/src/ordered_set.rs
+++ b/phf/src/ordered_set.rs
@@ -30,12 +30,26 @@ where
 
 impl<T> OrderedSet<T> {
     /// Returns the number of elements in the `OrderedSet`.
+    #[cfg(feature = "std")]
     pub fn len(&self) -> usize {
         self.map.len()
     }
 
+    /// Returns the number of elements in the `OrderedSet`.
+    #[cfg(not(feature = "std"))]
+    pub const fn len(&self) -> usize {
+        self.map.len()
+    }
+
     /// Returns true if the `OrderedSet` contains no elements.
+    #[cfg(feature = "std")]
     pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns true if the `OrderedSet` contains no elements.
+    #[cfg(not(feature = "std"))]
+    pub const fn is_empty(&self) -> bool {
         self.len() == 0
     }
 

--- a/phf/src/set.rs
+++ b/phf/src/set.rs
@@ -29,25 +29,13 @@ where
 
 impl<T> Set<T> {
     /// Returns the number of elements in the `Set`.
-    #[cfg(feature = "std")]
-    pub fn len(&self) -> usize {
-        self.map.len()
-    }
-
-    /// Returns the number of elements in the `Set`.
-    #[cfg(not(feature = "std"))]
+    #[inline]
     pub const fn len(&self) -> usize {
         self.map.len()
     }
 
     /// Returns true if the `Set` contains no elements.
-    #[cfg(feature = "std")]
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
-    /// Returns true if the `Set` contains no elements.
-    #[cfg(not(feature = "std"))]
+    #[inline]
     pub const fn is_empty(&self) -> bool {
         self.len() == 0
     }

--- a/phf/src/set.rs
+++ b/phf/src/set.rs
@@ -29,12 +29,26 @@ where
 
 impl<T> Set<T> {
     /// Returns the number of elements in the `Set`.
+    #[cfg(feature = "std")]
     pub fn len(&self) -> usize {
         self.map.len()
     }
 
+    /// Returns the number of elements in the `Set`.
+    #[cfg(not(feature = "std"))]
+    pub const fn len(&self) -> usize {
+        self.map.len()
+    }
+
     /// Returns true if the `Set` contains no elements.
+    #[cfg(feature = "std")]
     pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns true if the `Set` contains no elements.
+    #[cfg(not(feature = "std"))]
+    pub const fn is_empty(&self) -> bool {
         self.len() == 0
     }
 

--- a/phf_codegen/src/lib.rs
+++ b/phf_codegen/src/lib.rs
@@ -222,8 +222,8 @@ impl<'a, K: FmtConst + 'a> fmt::Display for DisplayMap<'a, K> {
             f,
             "{}::Map {{
     key: {:?},
-    disps: {}::Slice::Static(&[",
-            self.path, self.state.key, self.path
+    disps: &[",
+            self.path, self.state.key
         )?;
 
         // write map displacements
@@ -239,9 +239,8 @@ impl<'a, K: FmtConst + 'a> fmt::Display for DisplayMap<'a, K> {
         write!(
             f,
             "
-    ]),
-    entries: {}::Slice::Static(&[",
-            self.path
+    ],
+    entries: &[",
         )?;
 
         // write map entries
@@ -258,7 +257,7 @@ impl<'a, K: FmtConst + 'a> fmt::Display for DisplayMap<'a, K> {
         write!(
             f,
             "
-    ]),
+    ],
 }}"
         )
     }
@@ -383,8 +382,8 @@ impl<'a, K: FmtConst + 'a> fmt::Display for DisplayOrderedMap<'a, K> {
             f,
             "{}::OrderedMap {{
     key: {:?},
-    disps: {}::Slice::Static(&[",
-            self.path, self.state.key, self.path
+    disps: &[",
+            self.path, self.state.key
         )?;
         for &(d1, d2) in &self.state.disps {
             write!(
@@ -397,9 +396,8 @@ impl<'a, K: FmtConst + 'a> fmt::Display for DisplayOrderedMap<'a, K> {
         write!(
             f,
             "
-    ]),
-    idxs: {}::Slice::Static(&[",
-            self.path
+    ],
+    idxs: &[",
         )?;
         for &idx in &self.state.map {
             write!(
@@ -412,9 +410,8 @@ impl<'a, K: FmtConst + 'a> fmt::Display for DisplayOrderedMap<'a, K> {
         write!(
             f,
             "
-    ]),
-    entries: {}::Slice::Static(&[",
-            self.path
+    ],
+    entries: &[",
         )?;
         for (key, value) in self.keys.iter().zip(self.values.iter()) {
             write!(
@@ -428,7 +425,7 @@ impl<'a, K: FmtConst + 'a> fmt::Display for DisplayOrderedMap<'a, K> {
         write!(
             f,
             "
-    ]),
+    ],
 }}"
         )
     }

--- a/phf_macros/src/lib.rs
+++ b/phf_macros/src/lib.rs
@@ -257,8 +257,8 @@ fn build_map(entries: &[Entry], state: HashState) -> proc_macro2::TokenStream {
     quote! {
         phf::Map {
             key: #key,
-            disps: phf::Slice::Static(&[#(#disps),*]),
-            entries: phf::Slice::Static(&[#(#entries),*]),
+            disps: &[#(#disps),*],
+            entries: &[#(#entries),*],
         }
     }
 }
@@ -276,9 +276,9 @@ fn build_ordered_map(entries: &[Entry], state: HashState) -> proc_macro2::TokenS
     quote! {
         phf::OrderedMap {
             key: #key,
-            disps: phf::Slice::Static(&[#(#disps),*]),
-            idxs: phf::Slice::Static(&[#(#idxs),*]),
-            entries: phf::Slice::Static(&[#(#entries),*]),
+            disps: &[#(#disps),*],
+            idxs: &[#(#idxs),*],
+            entries: &[#(#entries),*],
         }
     }
 }


### PR DESCRIPTION
The `len` and `is_empty` functions of the four PHF types are upgraded to `const-fn`s.

## Implementation Detail

In this implementation, I could only upgrade them when the `std` feature is turned off because of the definition of `Slice`. I'm not sure what the purpose of the `Dynamic` variant is on `Slice`. Is there any reason we can't switch to `slice`?