### PR TITLE
Add trait implementations to Iterators mirroring the std::collections maps/sets

### DIFF
--- a/phf/src/map.rs
+++ b/phf/src/map.rs
@@ -1,5 +1,6 @@
 //! An immutable map constructed at compile time.
 use core::fmt;
+use core::iter::FusedIterator;
 use core::iter::IntoIterator;
 use core::ops::Index;
 use core::slice;
@@ -148,6 +149,25 @@ pub struct Entries<'a, K, V> {
     iter: slice::Iter<'a, (K, V)>,
 }
 
+impl<'a, K, V> Clone for Entries<'a, K, V> {
+    #[inline]
+    fn clone(&self) -> Self {
+        Self {
+            iter: self.iter.clone(),
+        }
+    }
+}
+
+impl<'a, K, V> fmt::Debug for Entries<'a, K, V>
+where
+    K: fmt::Debug,
+    V: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_list().entries(self.clone()).finish()
+    }
+}
+
 impl<'a, K, V> Iterator for Entries<'a, K, V> {
     type Item = (&'a K, &'a V);
 
@@ -168,9 +188,29 @@ impl<'a, K, V> DoubleEndedIterator for Entries<'a, K, V> {
 
 impl<'a, K, V> ExactSizeIterator for Entries<'a, K, V> {}
 
+impl<'a, K, V> FusedIterator for Entries<'a, K, V> {}
+
 /// An iterator over the keys in a `Map`.
 pub struct Keys<'a, K, V> {
     iter: Entries<'a, K, V>,
+}
+
+impl<'a, K, V> Clone for Keys<'a, K, V> {
+    #[inline]
+    fn clone(&self) -> Self {
+        Self {
+            iter: self.iter.clone(),
+        }
+    }
+}
+
+impl<'a, K, V> fmt::Debug for Keys<'a, K, V>
+where
+    K: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_list().entries(self.clone()).finish()
+    }
 }
 
 impl<'a, K, V> Iterator for Keys<'a, K, V> {
@@ -193,9 +233,29 @@ impl<'a, K, V> DoubleEndedIterator for Keys<'a, K, V> {
 
 impl<'a, K, V> ExactSizeIterator for Keys<'a, K, V> {}
 
+impl<'a, K, V> FusedIterator for Keys<'a, K, V> {}
+
 /// An iterator over the values in a `Map`.
 pub struct Values<'a, K, V> {
     iter: Entries<'a, K, V>,
+}
+
+impl<'a, K, V> Clone for Values<'a, K, V> {
+    #[inline]
+    fn clone(&self) -> Self {
+        Self {
+            iter: self.iter.clone(),
+        }
+    }
+}
+
+impl<'a, K, V> fmt::Debug for Values<'a, K, V>
+where
+    V: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_list().entries(self.clone()).finish()
+    }
 }
 
 impl<'a, K, V> Iterator for Values<'a, K, V> {
@@ -217,3 +277,5 @@ impl<'a, K, V> DoubleEndedIterator for Values<'a, K, V> {
 }
 
 impl<'a, K, V> ExactSizeIterator for Values<'a, K, V> {}
+
+impl<'a, K, V> FusedIterator for Values<'a, K, V> {}

--- a/phf/src/ordered_map.rs
+++ b/phf/src/ordered_map.rs
@@ -1,5 +1,6 @@
 //! An order-preserving immutable map constructed at compile time.
 use core::fmt;
+use core::iter::FusedIterator;
 use core::iter::IntoIterator;
 use core::ops::Index;
 use core::slice;
@@ -179,6 +180,25 @@ pub struct Entries<'a, K, V> {
     iter: slice::Iter<'a, (K, V)>,
 }
 
+impl<'a, K, V> Clone for Entries<'a, K, V> {
+    #[inline]
+    fn clone(&self) -> Self {
+        Self {
+            iter: self.iter.clone(),
+        }
+    }
+}
+
+impl<'a, K, V> fmt::Debug for Entries<'a, K, V>
+where
+    K: fmt::Debug,
+    V: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_list().entries(self.clone()).finish()
+    }
+}
+
 impl<'a, K, V> Iterator for Entries<'a, K, V> {
     type Item = (&'a K, &'a V);
 
@@ -199,9 +219,29 @@ impl<'a, K, V> DoubleEndedIterator for Entries<'a, K, V> {
 
 impl<'a, K, V> ExactSizeIterator for Entries<'a, K, V> {}
 
+impl<'a, K, V> FusedIterator for Entries<'a, K, V> {}
+
 /// An iterator over the keys in a `OrderedMap`.
 pub struct Keys<'a, K, V> {
     iter: Entries<'a, K, V>,
+}
+
+impl<'a, K, V> Clone for Keys<'a, K, V> {
+    #[inline]
+    fn clone(&self) -> Self {
+        Self {
+            iter: self.iter.clone(),
+        }
+    }
+}
+
+impl<'a, K, V> fmt::Debug for Keys<'a, K, V>
+where
+    K: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_list().entries(self.clone()).finish()
+    }
 }
 
 impl<'a, K, V> Iterator for Keys<'a, K, V> {
@@ -224,9 +264,29 @@ impl<'a, K, V> DoubleEndedIterator for Keys<'a, K, V> {
 
 impl<'a, K, V> ExactSizeIterator for Keys<'a, K, V> {}
 
+impl<'a, K, V> FusedIterator for Keys<'a, K, V> {}
+
 /// An iterator over the values in a `OrderedMap`.
 pub struct Values<'a, K, V> {
     iter: Entries<'a, K, V>,
+}
+
+impl<'a, K, V> Clone for Values<'a, K, V> {
+    #[inline]
+    fn clone(&self) -> Self {
+        Self {
+            iter: self.iter.clone(),
+        }
+    }
+}
+
+impl<'a, K, V> fmt::Debug for Values<'a, K, V>
+where
+    V: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_list().entries(self.clone()).finish()
+    }
 }
 
 impl<'a, K, V> Iterator for Values<'a, K, V> {
@@ -248,3 +308,5 @@ impl<'a, K, V> DoubleEndedIterator for Values<'a, K, V> {
 }
 
 impl<'a, K, V> ExactSizeIterator for Values<'a, K, V> {}
+
+impl<'a, K, V> FusedIterator for Values<'a, K, V> {}

--- a/phf/src/ordered_set.rs
+++ b/phf/src/ordered_set.rs
@@ -1,6 +1,7 @@
 //! An order-preserving immutable set constructed at compile time.
 use crate::{ordered_map, OrderedMap, PhfHash};
 use core::fmt;
+use core::iter::FusedIterator;
 use core::iter::IntoIterator;
 use phf_shared::PhfBorrow;
 
@@ -125,6 +126,24 @@ pub struct Iter<'a, T> {
     iter: ordered_map::Keys<'a, T, ()>,
 }
 
+impl<'a, T> Clone for Iter<'a, T> {
+    #[inline]
+    fn clone(&self) -> Self {
+        Self {
+            iter: self.iter.clone(),
+        }
+    }
+}
+
+impl<'a, T> fmt::Debug for Iter<'a, T>
+where
+    T: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_list().entries(self.clone()).finish()
+    }
+}
+
 impl<'a, T> Iterator for Iter<'a, T> {
     type Item = &'a T;
 
@@ -147,3 +166,5 @@ impl<'a, T> DoubleEndedIterator for Iter<'a, T> {
 }
 
 impl<'a, T> ExactSizeIterator for Iter<'a, T> {}
+
+impl<'a, T> FusedIterator for Iter<'a, T> {}

--- a/phf/src/set.rs
+++ b/phf/src/set.rs
@@ -1,5 +1,6 @@
 //! An immutable set constructed at compile time.
 use core::fmt;
+use core::iter::FusedIterator;
 use core::iter::IntoIterator;
 
 use phf_shared::{PhfBorrow, PhfHash};
@@ -105,6 +106,24 @@ pub struct Iter<'a, T: 'static> {
     iter: map::Keys<'a, T, ()>,
 }
 
+impl<'a, T> Clone for Iter<'a, T> {
+    #[inline]
+    fn clone(&self) -> Self {
+        Self {
+            iter: self.iter.clone(),
+        }
+    }
+}
+
+impl<'a, T> fmt::Debug for Iter<'a, T>
+where
+    T: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_list().entries(self.clone()).finish()
+    }
+}
+
 impl<'a, T> Iterator for Iter<'a, T> {
     type Item = &'a T;
 
@@ -124,3 +143,5 @@ impl<'a, T> DoubleEndedIterator for Iter<'a, T> {
 }
 
 impl<'a, T> ExactSizeIterator for Iter<'a, T> {}
+
+impl<'a, T> FusedIterator for Iter<'a, T> {}


### PR DESCRIPTION
Added `Clone`, `Debug`, and `FusedIterator` implementations for the map/set iterators following the implementations in the standard library.

Resolves #192.