### PR TITLE
Fix CI failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         # MSRV and nightly
-        version: [1.41.0, 1.46.0, nightly]
+        version: [1.46.0, nightly]
     steps:
       - uses: actions/checkout@v2
 
@@ -23,7 +23,7 @@ jobs:
           rustup override set ${{ matrix.version }}
 
       - name: Rustfmt check
-        if: matrix.version == '1.41.0'
+        if: matrix.version == '1.46.0'
         run: |
           rustup component add rustfmt
           cargo fmt --all -- --check
@@ -32,12 +32,11 @@ jobs:
         run: cargo test --workspace --exclude=phf_codegen_test
 
       - name: phf_macros UI test
-        if: matrix.version == '1.41.0'
+        if: matrix.version == '1.46.0'
         working-directory: phf_macros
         run: cargo test --features=unicase -- --ignored --test-threads=1
 
       - name: phf_codegen test
-        if: matrix.version != '1.41.0' # `uncased` requires 1.46 or higher.
         run: cargo test -p phf_codegen_test
 
       - name: no_std build check

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ a 100,000 entry map in roughly .4 seconds. By default statistics are not
 produced, but if you set the environment variable `PHF_STATS` it will issue
 a compiler note about how long it took.
 
-MSRV (minimum supported rust version) is Rust 1.41, or 1.46 if you use the `uncased` feature.
+MSRV (minimum supported rust version) is Rust 1.46.
 
 ## Usage
 

--- a/phf/src/lib.rs
+++ b/phf/src/lib.rs
@@ -8,12 +8,12 @@
 //! If the `macros` Cargo feature is enabled, the `phf_map`, `phf_set`,
 //! `phf_ordered_map`, and `phf_ordered_set` macros can be used to construct
 //! the PHF type. This method can be used with a stable compiler
-//! (minimum supported rust version is 1.41, or 1.46 if you use the `uncased`
+//! (minimum supported rust version is 1.46.
 //! feature).
 //!
 //! ```toml
 //! [dependencies]
-//! phf = { version = "0.9", features = ["macros"] }
+//! phf = { version = "0.10", features = ["macros"] }
 //! ```
 //!
 //! ```
@@ -45,7 +45,7 @@
 //!
 //! [#183]: https://github.com/rust-phf/rust-phf/issues/183
 //! [#196]: https://github.com/rust-phf/rust-phf/issues/196
-#![doc(html_root_url = "https://docs.rs/phf/0.9")]
+#![doc(html_root_url = "https://docs.rs/phf/0.10")]
 #![warn(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/phf_codegen/src/lib.rs
+++ b/phf_codegen/src/lib.rs
@@ -123,7 +123,7 @@
 //! builder.entry("world", "2");
 //! // ...
 //! ```
-#![doc(html_root_url = "https://docs.rs/phf_codegen/0.9")]
+#![doc(html_root_url = "https://docs.rs/phf_codegen/0.10")]
 
 use phf_shared::{FmtConst, PhfHash};
 use std::collections::HashSet;

--- a/phf_generator/src/lib.rs
+++ b/phf_generator/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/phf_generator/0.9")]
+#![doc(html_root_url = "https://docs.rs/phf_generator/0.10")]
 use phf_shared::{HashKey, PhfHash};
 use rand::distributions::Standard;
 use rand::rngs::SmallRng;

--- a/phf_macros/Cargo.toml
+++ b/phf_macros/Cargo.toml
@@ -27,5 +27,5 @@ phf_shared = { version = "0.10.0", default-features = false }
 
 [dev-dependencies]
 trybuild = "1.0"
-phf = { version = "0.9", features = ["macros", "unicase"] }
+phf = { version = "0.10", features = ["macros", "unicase"] }
 unicase_ = { package = "unicase", version = "2.4.0" }

--- a/phf_macros/tests/compile-fail-unicase/equivalent-keys.stderr
+++ b/phf_macros/tests/compile-fail-unicase/equivalent-keys.stderr
@@ -3,3 +3,5 @@ error: duplicate key
   |
 6 |     UniCase::ascii("foo") => 42, //~ ERROR duplicate key UniCase("FOO")
   |     ^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/phf_macros/tests/compile-fail/bad-syntax.stderr
+++ b/phf_macros/tests/compile-fail/bad-syntax.stderr
@@ -3,3 +3,5 @@ error: expected identifier
   |
 5 |     => //~ ERROR expected identifier
   |     ^^
+  |
+  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/phf_shared/src/lib.rs
+++ b/phf_shared/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/phf_shared/0.9")]
+#![doc(html_root_url = "https://docs.rs/phf_shared/0.10")]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(feature = "std")]


### PR DESCRIPTION
- Bumps up MSRV to 1.46 completely to fix CI.
- Updates some reference to the crate version.