### PR TITLE
Allow serializing `Map`.

### DIFF
--- a/phf/Cargo.toml
+++ b/phf/Cargo.toml
@@ -27,6 +27,7 @@ macros = [
 proc-macro-hack = { version = "0.5.4", optional = true }
 phf_macros = { version = "0.10.0", optional = true }
 phf_shared = { version = "0.10.0", default-features = false }
+serde = { version = "1.0", optional = true }
 
 [package.metadata.docs.rs]
 features = ["macros"]


### PR DESCRIPTION
Allow serializing `Map` with `serde`.