### PR TITLE
Derive Eq trait for maps

### DIFF
--- a/phf/src/map.rs
+++ b/phf/src/map.rs
@@ -15,6 +15,7 @@ use serde::ser::{Serialize, SerializeMap, Serializer};
 /// The fields of this struct are public so that they may be initialized by the
 /// `phf_map!` macro and code generation. They are subject to change at any
 /// time and should never be accessed directly.
+#[derive(PartialEq, Eq)]
 pub struct Map<K: 'static, V: 'static> {
     #[doc(hidden)]
     pub key: HashKey,

--- a/phf/src/ordered_map.rs
+++ b/phf/src/ordered_map.rs
@@ -16,6 +16,7 @@ use phf_shared::{self, HashKey, PhfBorrow, PhfHash};
 /// The fields of this struct are public so that they may be initialized by the
 /// `phf_ordered_map!` macro and code generation. They are subject to change at
 /// any time and should never be accessed directly.
+#[derive(PartialEq, Eq)]
 pub struct OrderedMap<K: 'static, V: 'static> {
     #[doc(hidden)]
     pub key: HashKey,

--- a/phf/src/ordered_set.rs
+++ b/phf/src/ordered_set.rs
@@ -15,6 +15,7 @@ use phf_shared::PhfBorrow;
 /// The fields of this struct are public so that they may be initialized by the
 /// `phf_ordered_set!` macro and code generation. They are subject to change at
 /// any time and should never be accessed directly.
+#[derive(PartialEq, Eq)]
 pub struct OrderedSet<T: 'static> {
     #[doc(hidden)]
     pub map: OrderedMap<T, ()>,

--- a/phf/src/set.rs
+++ b/phf/src/set.rs
@@ -14,6 +14,7 @@ use crate::{map, Map};
 /// The fields of this struct are public so that they may be initialized by the
 /// `phf_set!` macro and code generation. They are subject to change at any
 /// time and should never be accessed directly.
+#[derive(PartialEq, Eq)]
 pub struct Set<T: 'static> {
     #[doc(hidden)]
     pub map: Map<T, ()>,


### PR DESCRIPTION
This is useful if phf maps are included as part of other (usually static) types which you wish to compare for equality.