### PR TITLE
Implement PhfHash for integral arrays of any size.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         # MSRV and nightly
-        version: [1.46.0, nightly]
+        version: [1.51.0, nightly]
     steps:
       - uses: actions/checkout@v2
 
@@ -23,7 +23,7 @@ jobs:
           rustup override set ${{ matrix.version }}
 
       - name: Rustfmt check
-        if: matrix.version == '1.46.0'
+        if: matrix.version == '1.51.0'
         run: |
           rustup component add rustfmt
           cargo fmt --all -- --check
@@ -32,7 +32,7 @@ jobs:
         run: cargo test --workspace --exclude=phf_codegen_test
 
       - name: phf_macros UI test
-        if: matrix.version == '1.46.0'
+        if: matrix.version == '1.51.0'
         working-directory: phf_macros_tests
         run: cargo test -- --ignored --test-threads=1
 

--- a/phf_shared/src/lib.rs
+++ b/phf_shared/src/lib.rs
@@ -364,7 +364,7 @@ impl PhfHash for char {
 }
 
 // minimize duplicated code since formatting drags in quite a bit
-fn fmt_array<T: std::fmt::Debug>(array: &[T], f: &mut fmt::Formatter<'_>) -> fmt::Result {
+fn fmt_array<T: core::fmt::Debug>(array: &[T], f: &mut fmt::Formatter<'_>) -> fmt::Result {
     write!(f, "{:?}", array)
 }
 
@@ -373,19 +373,19 @@ macro_rules! array_impl (
         impl<const N: usize> PhfHash for [$t; N] {
             #[inline]
             fn phf_hash<H: Hasher>(&self, state: &mut H) {
-                for v in self {
+                for v in &self[..] {
                     v.phf_hash(state);
                 }
             }
         }
 
-        impl<const N: usize>  FmtConst for [$t; N] {
+        impl<const N: usize> FmtConst for [$t; N] {
             fn fmt_const(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 fmt_array(self, f)
             }
         }
 
-        impl<const N: usize>  PhfBorrow<[$t]> for [$t; N] {
+        impl<const N: usize> PhfBorrow<[$t]> for [$t; N] {
             fn borrow(&self) -> &[$t] {
                 self
             }

--- a/phf_shared/src/lib.rs
+++ b/phf_shared/src/lib.rs
@@ -364,26 +364,28 @@ impl PhfHash for char {
 }
 
 // minimize duplicated code since formatting drags in quite a bit
-fn fmt_array(array: &[u8], f: &mut fmt::Formatter<'_>) -> fmt::Result {
+fn fmt_array<T: std::fmt::Debug>(array: &[T], f: &mut fmt::Formatter<'_>) -> fmt::Result {
     write!(f, "{:?}", array)
 }
 
 macro_rules! array_impl (
-    ($t:ty, $n:expr) => (
-        impl PhfHash for [$t; $n] {
+    ($t:ty) => (
+        impl<const N: usize> PhfHash for [$t; N] {
             #[inline]
             fn phf_hash<H: Hasher>(&self, state: &mut H) {
-                state.write(self);
+                for v in self {
+                    v.phf_hash(state);
+                }
             }
         }
 
-        impl FmtConst for [$t; $n] {
+        impl<const N: usize>  FmtConst for [$t; N] {
             fn fmt_const(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 fmt_array(self, f)
             }
         }
 
-        impl PhfBorrow<[$t]> for [$t; $n] {
+        impl<const N: usize>  PhfBorrow<[$t]> for [$t; N] {
             fn borrow(&self) -> &[$t] {
                 self
             }
@@ -391,35 +393,15 @@ macro_rules! array_impl (
     )
 );
 
-array_impl!(u8, 1);
-array_impl!(u8, 2);
-array_impl!(u8, 3);
-array_impl!(u8, 4);
-array_impl!(u8, 5);
-array_impl!(u8, 6);
-array_impl!(u8, 7);
-array_impl!(u8, 8);
-array_impl!(u8, 9);
-array_impl!(u8, 10);
-array_impl!(u8, 11);
-array_impl!(u8, 12);
-array_impl!(u8, 13);
-array_impl!(u8, 14);
-array_impl!(u8, 15);
-array_impl!(u8, 16);
-array_impl!(u8, 17);
-array_impl!(u8, 18);
-array_impl!(u8, 19);
-array_impl!(u8, 20);
-array_impl!(u8, 21);
-array_impl!(u8, 22);
-array_impl!(u8, 23);
-array_impl!(u8, 24);
-array_impl!(u8, 25);
-array_impl!(u8, 26);
-array_impl!(u8, 27);
-array_impl!(u8, 28);
-array_impl!(u8, 29);
-array_impl!(u8, 30);
-array_impl!(u8, 31);
-array_impl!(u8, 32);
+array_impl!(u8);
+array_impl!(i8);
+array_impl!(u16);
+array_impl!(i16);
+array_impl!(u32);
+array_impl!(i32);
+array_impl!(u64);
+array_impl!(i64);
+array_impl!(u128);
+array_impl!(i128);
+array_impl!(bool);
+array_impl!(char);


### PR DESCRIPTION
This might be useful, but I'm not sure if it's ok to force Rust 1.51+.