### PR TITLE
Add `Map::new()` function and `Default` implementation to create new, empty map

### DIFF
--- a/phf/src/map.rs
+++ b/phf/src/map.rs
@@ -47,6 +47,16 @@ where
 }
 
 impl<K, V> Map<K, V> {
+    /// Create a new, empty, immutable map.
+    #[inline]
+    pub const fn new_empty() -> Self {
+        Self {
+            key: 0,
+            disps: &[],
+            entries: &[],
+        }
+    }
+
     /// Returns the number of entries in the `Map`.
     #[inline]
     pub const fn len(&self) -> usize {

--- a/phf/src/map.rs
+++ b/phf/src/map.rs
@@ -46,6 +46,12 @@ where
     }
 }
 
+impl<K, V> Default for Map<K, V> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<K, V> Map<K, V> {
     /// Create a new, empty, immutable map.
     #[inline]

--- a/phf/src/map.rs
+++ b/phf/src/map.rs
@@ -49,7 +49,7 @@ where
 impl<K, V> Map<K, V> {
     /// Create a new, empty, immutable map.
     #[inline]
-    pub const fn new_empty() -> Self {
+    pub const fn new() -> Self {
         Self {
             key: 0,
             disps: &[],


### PR DESCRIPTION
This allows for creating empty maps without having to compile macros or codegen first.