### PR TITLE
fix: remove now-unnecessary `proc-macro-hack` crate usage

### DIFF
--- a/phf/Cargo.toml
+++ b/phf/Cargo.toml
@@ -19,13 +19,9 @@ default = ["std"]
 std = ["phf_shared/std"]
 uncased = ["phf_shared/uncased"]
 unicase = ["phf_macros?/unicase", "phf_shared/unicase"]
-macros = [
-    "phf_macros",
-    "proc-macro-hack",
-]
+macros = ["phf_macros"]
 
 [dependencies]
-proc-macro-hack = { version = "0.5.4", optional = true }
 phf_macros = { version = "0.10.0", optional = true, path = "../phf_macros" }
 phf_shared = { version = "0.10.0", default-features = false, path = "../phf_shared" }
 serde = { version = "1.0", optional = true }

--- a/phf/Cargo.toml
+++ b/phf/Cargo.toml
@@ -26,8 +26,8 @@ macros = [
 
 [dependencies]
 proc-macro-hack = { version = "0.5.4", optional = true }
-phf_macros = { version = "0.10.0", optional = true }
-phf_shared = { version = "0.10.0", default-features = false }
+phf_macros = { version = "0.10.0", optional = true, path = "../phf_macros" }
+phf_shared = { version = "0.10.0", default-features = false, path = "../phf_shared" }
 serde = { version = "1.0", optional = true }
 
 [package.metadata.docs.rs]

--- a/phf/src/lib.rs
+++ b/phf/src/lib.rs
@@ -102,14 +102,12 @@ extern crate std as core;
 ///     assert_eq!(MY_MAP["hello"], 1);
 /// }
 /// ```
-#[proc_macro_hack::proc_macro_hack]
 pub use phf_macros::phf_map;
 
 #[cfg(feature = "macros")]
 /// Macro to create a `static` (compile-time) [`OrderedMap`].
 ///
 /// Requires the `macros` feature. Same usage as [`phf_map`].
-#[proc_macro_hack::proc_macro_hack]
 pub use phf_macros::phf_ordered_map;
 
 #[cfg(feature = "macros")]
@@ -131,14 +129,12 @@ pub use phf_macros::phf_ordered_map;
 ///     assert!(MY_SET.contains("hello world"));
 /// }
 /// ```
-#[proc_macro_hack::proc_macro_hack]
 pub use phf_macros::phf_set;
 
 #[cfg(feature = "macros")]
 /// Macro to create a `static` (compile-time) [`OrderedSet`].
 ///
 /// Requires the `macros` feature. Same usage as [`phf_set`].
-#[proc_macro_hack::proc_macro_hack]
 pub use phf_macros::phf_ordered_set;
 
 #[doc(inline)]

--- a/phf_macros/Cargo.toml
+++ b/phf_macros/Cargo.toml
@@ -20,7 +20,6 @@ unicase = ["unicase_", "phf_shared/unicase"]
 syn = { version = "1", features = ["full"] }
 quote = "1"
 proc-macro2 = "1"
-proc-macro-hack = "0.5.4"
 unicase_ = { package = "unicase", version = "2.4.0", optional = true }
 
 phf_generator = "0.10.0"

--- a/phf_macros/src/lib.rs
+++ b/phf_macros/src/lib.rs
@@ -285,7 +285,7 @@ fn build_ordered_map(entries: &[Entry], state: HashState) -> proc_macro2::TokenS
     }
 }
 
-#[proc_macro_hack::proc_macro_hack]
+#[proc_macro]
 pub fn phf_map(input: TokenStream) -> TokenStream {
     let map = parse_macro_input!(input as Map);
     let state = phf_generator::generate_hash(&map.0);
@@ -293,7 +293,7 @@ pub fn phf_map(input: TokenStream) -> TokenStream {
     build_map(&map.0, state).into()
 }
 
-#[proc_macro_hack::proc_macro_hack]
+#[proc_macro]
 pub fn phf_set(input: TokenStream) -> TokenStream {
     let set = parse_macro_input!(input as Set);
     let state = phf_generator::generate_hash(&set.0);
@@ -302,7 +302,7 @@ pub fn phf_set(input: TokenStream) -> TokenStream {
     quote!(phf::Set { map: #map }).into()
 }
 
-#[proc_macro_hack::proc_macro_hack]
+#[proc_macro]
 pub fn phf_ordered_map(input: TokenStream) -> TokenStream {
     let map = parse_macro_input!(input as Map);
     let state = phf_generator::generate_hash(&map.0);
@@ -310,7 +310,7 @@ pub fn phf_ordered_map(input: TokenStream) -> TokenStream {
     build_ordered_map(&map.0, state).into()
 }
 
-#[proc_macro_hack::proc_macro_hack]
+#[proc_macro]
 pub fn phf_ordered_set(input: TokenStream) -> TokenStream {
     let set = parse_macro_input!(input as Set);
     let state = phf_generator::generate_hash(&set.0);

--- a/phf_macros_tests/tests/compile-fail-unicase/equivalent-keys.stderr
+++ b/phf_macros_tests/tests/compile-fail-unicase/equivalent-keys.stderr
@@ -3,5 +3,3 @@ error: duplicate key
   |
 6 |     UniCase::ascii("foo") => 42, //~ ERROR duplicate key UniCase("FOO")
   |     ^^^^^^^^^^^^^^^^^^^^^
-  |
-  = note: this error originates in the macro `proc_macro_call` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/phf_macros_tests/tests/compile-fail/bad-syntax.stderr
+++ b/phf_macros_tests/tests/compile-fail/bad-syntax.stderr
@@ -3,5 +3,3 @@ error: expected identifier
   |
 5 |     => //~ ERROR expected identifier
   |     ^^
-  |
-  = note: this error originates in the macro `proc_macro_call` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
Resolves <https://github.com/rust-phf/rust-phf/issues/255>.

This resolves an issue with Windows Defender identifying `proc-macro-hack` as threats. It also sheds a depedency that is no longer necessary, now that the MSRV of this crate is 1.46 and `proc-macro-hack` is only useful for providing support for Rust versions 1.31 through 1.45. Per [upstream](https://github.com/dtolnay/proc-macro-hack):

> **Note:** _As of Rust 1.45 this crate is superseded by native support for #\[proc\_macro\] in expression position. Only consider using this crate if you care about supporting compilers between 1.31 and 1.45._