### PR TITLE
Disable default features for rand dep in phf_generator

### DIFF
--- a/phf_generator/Cargo.toml
+++ b/phf_generator/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["data-structures"]
 readme = "README.md"
 
 [dependencies]
-rand = { version = "0.8", features = ["small_rng"] }
+rand = { version = "0.8", default-features = false, features = ["small_rng"] }
 phf_shared = { version = "0.11.0", default-features = false }
 # for stable black_box()
 criterion = { version = "=0.3.4", optional = true }


### PR DESCRIPTION
These dependencies are not needed when using distributions and small_rng.