### PR TITLE
Improved GitHub Actions configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+env:
+  CARGO_TERM_COLOR: always
+
 jobs:
   ci:
     name: CI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [master]
   pull_request:
+  workflow_dispatch:
 
 jobs:
   ci:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ env:
 
 jobs:
   ci:
+    if: "!contains(github.event.head_commit.message, '[ci skip]')"
     name: CI
     runs-on: ubuntu-22.04
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,12 @@ jobs:
           rustup component add rustfmt
           cargo fmt --all -- --check
 
+      - name: Clippy check
+        if: matrix.version == '1.60.0'
+        run: |
+          rustup component add clippy
+          cargo clippy --all -- -D warnings
+
       - name: Run `cargo test` on workspace
         run: cargo test --workspace --exclude=phf_codegen_test
 


### PR DESCRIPTION
I'm not sure about cargo clippy. Please see if it does something wrong.
On `1.69.0-nightly (ef934d9b6 2023-02-08)` `cargo clippy --all --fix` produces the following changes. 
```diff
diff --git a/phf/src/map.rs b/phf/src/map.rs
index b5c7d10..790e1de 100644
--- a/phf/src/map.rs
+++ b/phf/src/map.rs
@@ -190,7 +190,7 @@ impl<'a, K, V> Iterator for Entries<'a, K, V> {
     type Item = (&'a K, &'a V);
 
     fn next(&mut self) -> Option<(&'a K, &'a V)> {
-        self.iter.next().map(|&(ref k, ref v)| (k, v))
+        self.iter.next().map(|(k, v)| (k, v))
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
diff --git a/phf/src/ordered_map.rs b/phf/src/ordered_map.rs
index 0d5bdad..f2c50e0 100644
--- a/phf/src/ordered_map.rs
+++ b/phf/src/ordered_map.rs
@@ -105,7 +105,7 @@ impl<K, V> OrderedMap<K, V> {
     /// Returns references to both the key and values at an index
     /// within the list used to initialize the ordered map. See `.get_index(key)`.
     pub fn index(&self, index: usize) -> Option<(&K, &V)> {
-        self.entries.get(index).map(|&(ref k, ref v)| (k, v))
+        self.entries.get(index).map(|(k, v)| (k, v))
     }
 
     /// Like `get`, but returns both the key and the value.
diff --git a/phf_codegen/src/lib.rs b/phf_codegen/src/lib.rs
index 6673c70..9ed4d42 100644
--- a/phf_codegen/src/lib.rs
+++ b/phf_codegen/src/lib.rs
@@ -247,8 +247,7 @@ impl<'a, K: FmtConst + 'a> fmt::Display for DisplayMap<'a, K> {
             write!(
                 f,
                 "
-        ({}, {}),",
-                d1, d2
+        ({d1}, {d2}),"
             )?;
         }
 
@@ -405,8 +404,7 @@ impl<'a, K: FmtConst + 'a> fmt::Display for DisplayOrderedMap<'a, K> {
             write!(
                 f,
                 "
-        ({}, {}),",
-                d1, d2
+        ({d1}, {d2}),"
             )?;
         }
         write!(
@@ -419,8 +417,7 @@ impl<'a, K: FmtConst + 'a> fmt::Display for DisplayOrderedMap<'a, K> {
             write!(
                 f,
                 "
-        {},",
-                idx
+        {idx},"
             )?;
         }
         write!(
diff --git a/phf_codegen/test/build.rs b/phf_codegen/test/build.rs
index 94235d5..2c735cd 100644
--- a/phf_codegen/test/build.rs
+++ b/phf_codegen/test/build.rs
@@ -8,7 +8,7 @@ use unicase::UniCase;
 
 fn main() -> io::Result<()> {
     let file = Path::new(&env::var("OUT_DIR").unwrap()).join("codegen.rs");
-    let mut file = BufWriter::new(File::create(&file)?);
+    let mut file = BufWriter::new(File::create(file)?);
 
     writeln!(
         &mut file,
diff --git a/phf_shared/src/lib.rs b/phf_shared/src/lib.rs
index 9de094b..4abed85 100644
--- a/phf_shared/src/lib.rs
+++ b/phf_shared/src/lib.rs
@@ -263,7 +263,7 @@ impl FmtConst for [u8] {
     #[inline]
     fn fmt_const(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // slices need a leading reference
-        write!(f, "&{:?}", self)
+        write!(f, "&{self:?}")
     }
 }
 
@@ -371,7 +371,7 @@ impl PhfHash for char {
 
 // minimize duplicated code since formatting drags in quite a bit
 fn fmt_array<T: core::fmt::Debug>(array: &[T], f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    write!(f, "{:?}", array)
+    write!(f, "{array:?}")
 }
 
 macro_rules! array_impl (
 ```