### PR TITLE
Allow using dereferenced bytestring literal keys in phf_map!

### DIFF
--- a/phf/src/lib.rs
+++ b/phf/src/lib.rs
@@ -86,6 +86,7 @@ extern crate std as core;
 /// Supported key expressions are:
 /// - literals: bools, (byte) strings, bytes, chars, and integers (these must have a type suffix)
 /// - arrays of `u8` integers
+/// - dereferenced byte string literals
 /// - `UniCase::unicode(string)` or `UniCase::ascii(string)` if the `unicase` feature is enabled
 ///
 /// # Example

--- a/phf_macros_tests/tests/test.rs
+++ b/phf_macros_tests/tests/test.rs
@@ -17,6 +17,11 @@ mod map {
         b"camembert" => "delicious",
     );
 
+    #[allow(dead_code)]
+    static DEREF_BYTE_STRING_KEY: phf::Map<[u8; 9], &'static str> = phf_map!(
+        *b"camembert" => "delicious",
+    );
+
     #[test]
     fn test_two() {
         static MAP: phf::Map<&'static str, isize> = phf_map!(


### PR DESCRIPTION
Hello, first I would like to say thank you for the crate, it is quite high quality. I noticed that `phf_map!` supports using `u8` array literals for keys. But in some cases I found it is easier to use byte strings of a fixed size, i.e. when keys may have a lot of ascii characters.

The problem is a byte string is of type `&[u8; N]` and has to be dereferenced to convert it to a value type. This PR makes it so a `*` operator can be put in front of a byte string literal so it works properly. And then things like this can be done:

```rust
static M: phf::Map<[u8; 8], u64> = phf::phf_map! {
    *b"qwertyiu" => 0u64,
    *b"abcdabcd" => 1u64,
};
```