### PR TITLE
Implement PartialEq and Eq for map and set types (closes #246)

### DIFF
--- a/phf/src/map.rs
+++ b/phf/src/map.rs
@@ -52,6 +52,23 @@ impl<K, V> Default for Map<K, V> {
     }
 }
 
+impl<K, V> PartialEq for Map<K, V>
+where
+    K: PartialEq,
+    V: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.key == other.key && self.disps == other.disps && self.entries == other.entries
+    }
+}
+
+impl<K, V> Eq for Map<K, V>
+where
+    K: Eq,
+    V: Eq,
+{
+}
+
 impl<K, V> Map<K, V> {
     /// Create a new, empty, immutable map.
     #[inline]

--- a/phf/src/ordered_map.rs
+++ b/phf/src/ordered_map.rs
@@ -49,6 +49,26 @@ where
     }
 }
 
+impl<K, V> PartialEq for OrderedMap<K, V>
+where
+    K: PartialEq,
+    V: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.key == other.key
+            && self.disps == other.disps
+            && self.idxs == other.idxs
+            && self.entries == other.entries
+    }
+}
+
+impl<K, V> Eq for OrderedMap<K, V>
+where
+    K: Eq,
+    V: Eq,
+{
+}
+
 impl<K, V> OrderedMap<K, V> {
     /// Returns the number of entries in the `OrderedMap`.
     #[inline]

--- a/phf/src/ordered_set.rs
+++ b/phf/src/ordered_set.rs
@@ -29,6 +29,17 @@ where
     }
 }
 
+impl<T> PartialEq for OrderedSet<T>
+where
+    T: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.map == other.map
+    }
+}
+
+impl<T> Eq for OrderedSet<T> where T: Eq {}
+
 impl<T> OrderedSet<T> {
     /// Returns the number of elements in the `OrderedSet`.
     #[inline]

--- a/phf/src/set.rs
+++ b/phf/src/set.rs
@@ -28,6 +28,17 @@ where
     }
 }
 
+impl<T> PartialEq for Set<T>
+where
+    T: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.map == other.map
+    }
+}
+
+impl<T> Eq for Set<T> where T: Eq {}
+
 impl<T> Set<T> {
     /// Returns the number of elements in the `Set`.
     #[inline]


### PR DESCRIPTION
This addresses the same issue as #246, but constrains `PartialEq` and `Eq` on key/value types that also implement those traits, to avoid the problem of requiring all types to implement those traits.