### PR TITLE
Bump uncased dep; remove generated transmute

### DIFF
--- a/phf_shared/Cargo.toml
+++ b/phf_shared/Cargo.toml
@@ -22,4 +22,4 @@ std = []
 [dependencies]
 siphasher = "0.3"
 unicase = { version = "2.4.0", optional = true }
-uncased = { version = "0.9.6", optional = true, default-features = false }
+uncased = { version = "0.9.9", optional = true, default-features = false }

--- a/phf_shared/src/lib.rs
+++ b/phf_shared/src/lib.rs
@@ -313,12 +313,9 @@ impl PhfHash for uncased::UncasedStr {
 #[cfg(feature = "uncased")]
 impl FmtConst for uncased::UncasedStr {
     fn fmt_const(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // transmute is not stable in const fns (rust-lang/rust#53605), so
-        // `UncasedStr::new` can't be a const fn itself, but we can inline the
-        // call to transmute here in the meantime.
-        f.write_str("unsafe { ::core::mem::transmute::<&'static str, &'static UncasedStr>(")?;
+        f.write_str("UncasedStr::new(")?;
         self.as_str().fmt_const(f)?;
-        f.write_str(") }")
+        f.write_str(")")
     }
 }
 


### PR DESCRIPTION
The mentioned function has been const since Rust 1.56, which is past the MSRV of this crate.