### PR TITLE
phf_macros: include LICENSE and changelog files in published crates

### DIFF
--- a/phf_macros/Cargo.toml
+++ b/phf_macros/Cargo.toml
@@ -7,7 +7,6 @@ license = "MIT"
 description = "Macros to generate types in the phf crate"
 repository = "https://github.com/rust-phf/rust-phf"
 readme = "../README.md"
-include = ["src/lib.rs"]
 rust-version = "1.60"
 categories = ["data-structures"]
 


### PR DESCRIPTION
The restrictive "include" directive is only present in the phf_macros
crate but in none of the others. This commit brings phf_macros crate
in line with other crates in this workspace.

This is a followup for #118 , where the "include" directive was apparently
missed.