### PR TITLE
Bump MSRV to 1.61

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         # MSRV and nightly
-        version: [1.60.0, nightly]
+        version: [1.61.0, nightly]
     steps:
       - uses: actions/checkout@v3
 
@@ -25,7 +25,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2.0.0
 
       - name: Rustfmt check
-        if: matrix.version == '1.60.0'
+        if: matrix.version == '1.61.0'
         run: |
           rustup component add rustfmt
           cargo fmt --all -- --check
@@ -34,7 +34,7 @@ jobs:
         run: cargo test --workspace --exclude=phf_codegen_test
 
       - name: phf_macros UI test
-        if: matrix.version == '1.60.0'
+        if: matrix.version == '1.61.0'
         working-directory: phf_macros_tests
         run: cargo test -- --ignored --test-threads=1
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It currently uses the
 [CHD algorithm](http://cmph.sourceforge.net/papers/esa09.pdf) and can generate
 a 100,000 entry map in roughly .4 seconds.
 
-MSRV (minimum supported rust version) is Rust 1.60.
+MSRV (minimum supported rust version) is Rust 1.61.
 
 ## Usage
 

--- a/phf/Cargo.toml
+++ b/phf/Cargo.toml
@@ -7,7 +7,7 @@ description = "Runtime support for perfect hash function data structures"
 repository = "https://github.com/rust-phf/rust-phf"
 edition = "2021"
 readme = "../README.md"
-rust-version = "1.60"
+rust-version = "1.61"
 categories = ["data-structures", "no-std"]
 
 [lib]

--- a/phf/examples/unicase-example/Cargo.toml
+++ b/phf/examples/unicase-example/Cargo.toml
@@ -2,7 +2,7 @@
 name = "unicase-example"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.61"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/phf/src/lib.rs
+++ b/phf/src/lib.rs
@@ -5,7 +5,7 @@
 //! [CHD algorithm](http://cmph.sourceforge.net/papers/esa09.pdf) and can generate
 //! a 100,000 entry map in roughly .4 seconds.
 //!
-//! MSRV (minimum supported rust version) is Rust 1.60.
+//! MSRV (minimum supported rust version) is Rust 1.61.
 //!
 //! ## Usage
 //!

--- a/phf_codegen/Cargo.toml
+++ b/phf_codegen/Cargo.toml
@@ -7,7 +7,7 @@ description = "Codegen library for PHF types"
 repository = "https://github.com/rust-phf/rust-phf"
 edition = "2021"
 readme = "../README.md"
-rust-version = "1.60"
+rust-version = "1.61"
 categories = ["data-structures"]
 
 [dependencies]

--- a/phf_generator/Cargo.toml
+++ b/phf_generator/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 description = "PHF generation logic"
 repository = "https://github.com/rust-phf/rust-phf"
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.61"
 categories = ["data-structures"]
 readme = "README.md"
 

--- a/phf_macros/Cargo.toml
+++ b/phf_macros/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 description = "Macros to generate types in the phf crate"
 repository = "https://github.com/rust-phf/rust-phf"
 readme = "../README.md"
-rust-version = "1.60"
+rust-version = "1.61"
 categories = ["data-structures"]
 
 [lib]

--- a/phf_macros_tests/Cargo.toml
+++ b/phf_macros_tests/Cargo.toml
@@ -3,7 +3,7 @@ name = "phf_macros_tests"
 version = "0.1.0"
 authors = ["Yuki Okushi <jtitor@2k36.org>"]
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.61"
 repository = "https://github.com/rust-phf/rust-phf"
 categories = ["data-structures"]
 

--- a/phf_shared/Cargo.toml
+++ b/phf_shared/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 description = "Support code shared by PHF libraries"
 repository = "https://github.com/rust-phf/rust-phf"
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.61"
 categories = ["data-structures"]
 readme = "README.md"
 


### PR DESCRIPTION
Because of:
```sh
package `memchr v2.6.4` cannot be built because it requires rustc 1.61 or newer, while the currently active rustc version is 1.60.0
```