### PR TITLE
Add support for stringify!() macro calls for key expressions

### DIFF
--- a/phf_macros/src/lib.rs
+++ b/phf_macros/src/lib.rs
@@ -139,7 +139,6 @@ impl ParsedKey {
                 }
             }
             Expr::Group(group) => ParsedKey::from_expr(&group.expr),
-            // A call to a `stringify!()` macro
             // TODO: Is it possible to modify this so that it evaluates the final expansion of any macro invocations,
             //  and only afterwards does the parsing
             Expr::Macro(ExprMacro{mac: Macro{tokens, path, ..}, ..})


### PR DESCRIPTION
# Explanation

This PR adds (very basic) support for using the `stringify!()` macro inside key-value expressions for the `phf_map!()` macro:
- Can be present directly as a key expression
- Can also be nested inside a call to `UniCase::ascii()` or `UniCase::unicode()`

Currently the logic is very basic and simply does an `Expr::Macro(...)` match, and if the path is `stringify!()` it just calls `to_string()` on the tokens to the macro call. Obviously this is not the best way to do so, however I'm not familiar with how `syn` works, and this is mostly a proof-of-concept/MVP.

Ideally, this would be expanded so that the entirety of the expression is expanded first, and then processed (so that any inner macro invocations are processed before `phf_map!()`, but I don't know how (if possible) to do this.

# Motivation
I recently ran into an issue where I was using macros to generate a bunch of code for creating a compile-time map of builtin colours using the `phf_map!()` macro. My current setup defines a bunch of colours using a macro. I need to generate both compile-time colours (as `static` fields), and some sort of dynamic colour evaluation (which in this case needs to be some sort of `String => Colour` map. The following code was what I needed to work, but didn't.

```rust
pub struct Colour {
    pub r: f64,
    pub g: f64,
    pub b: f64,
}

#[rustfmt::skip]
macro_rules! builtin_colour {
    ($name:ident, $val:expr) 
        => { builtin_colour!($name, ($val, $val, $val)); };
    ($name:ident, ($r:expr, $g:expr, $b:expr))
        => { builtin_colour!($name, Self { r: $r, g: $g, b: $b, }); };
    ($name:ident, $expr:expr)
        => { pub const $name: Self = $expr; };
}

macro_rules! builtin_colours {
    ( $( {$name:ident : $value:tt} ),+ ) => {
        $( builtin_colour!($name, $value); )+

        /// A map of all the builtin colours, indexed by name.
        /// These are functionally equivalent to `Colour::NAME`, but for run-time
        pub const COLOURS_MAP: phf::map::Map<UniCase<&'static str>, &'static Colour> = phf::phf_map! {
            $( UniCase::ascii(stringify!($name)) => &Colour::$name ),+
        };
    };
}


impl Colour {
    builtin_colours! {
        {BLACK:         (0.0)},
        {DARK_GREY:     (0.25)},
        {HALF_GREY:     (0.5)},
        {LIGHT_GREY:    (0.75)},
        {WHITE:         (1.0)},
        {RED:           (1.0, 0.0, 0.0)},
        {ORANGE:        (1.0, 0.15, 0.0)},
        {YELLOW:        (1.0, 0.4, 0.0)},
        {LIME:          (0.7, 1.0, 0.0)},
        {GREEN:         (0.0, 1.0, 0.0)},
        {AQUA:          (0.0, 1.0, 0.5)},
        {CYAN:          (0.0, 0.62, 0.63)},
        {SKY_BLUE:      (0.0, 0.8, 1.0)},
        {BLUE:          (0.0, 0.0, 1.0)},
        {PURPLE:        (0.48, 0.0, 1.0)},
        {HOT_PURPLE:    (0.72, 0.0, 1.0)},
        {HOT_PINK:      (1.0, 0.0, 1.0)}
    }
}
```

This would eventually expand to something like
```rust
phf_map! {
    UniCase::ascii(stringify!(BLACK)) => &Colour::BLACK
}
```

`stringify!()` is a macro, and for some reason the invocation is not expanded by the compiler, so when `phf_map` runs it sees an `Expr::Macro()` token, as opposed to the target literal. This then means that the patterns don't match, so the parser can't parse the keys and compilation fails with "Unsupported Key Expression".

This PR fixes that, so the above shown code compiles successfully, giving the following code (from `cargo-expand`):
```rust
         /// A map of all the builtin colours, indexed by name.
        /// These are functionally equivalent to `Colour::NAME`, but for run-time
        pub const COLOURS_MAP: phf::map::Map<UniCase<&'static str>, &'static Colour> = phf::Map {
            key: 10121458955350035957u64,
            disps: &[(2u32, 4u32), (0u32, 1u32), (2u32, 4u32), (0u32, 0u32)],
            entries: &[
                (UniCase::ascii("PURPLE"), &Colour::PURPLE),
                (UniCase::ascii("HALF_GREY"), &Colour::HALF_GREY),
                (UniCase::ascii("YELLOW"), &Colour::YELLOW),
                (UniCase::ascii("LIGHT_GREY"), &Colour::LIGHT_GREY),
                (UniCase::ascii("RED"), &Colour::RED),
                (UniCase::ascii("DARK_GREY"), &Colour::DARK_GREY),
                (UniCase::ascii("AQUA"), &Colour::AQUA),
                (UniCase::ascii("HOT_PURPLE"), &Colour::HOT_PURPLE),
                (UniCase::ascii("HOT_PINK"), &Colour::HOT_PINK),
                (UniCase::ascii("WHITE"), &Colour::WHITE),
                (UniCase::ascii("SKY_BLUE"), &Colour::SKY_BLUE),
                (UniCase::ascii("CYAN"), &Colour::CYAN),
                (UniCase::ascii("BLUE"), &Colour::BLUE),
                (UniCase::ascii("GREEN"), &Colour::GREEN),
                (UniCase::ascii("LIME"), &Colour::LIME),
                (UniCase::ascii("BLACK"), &Colour::BLACK),
                (UniCase::ascii("ORANGE"), &Colour::ORANGE),
            ],
        };
```