### PR TITLE
Macro support for uncased

### DIFF
--- a/phf/Cargo.toml
+++ b/phf/Cargo.toml
@@ -18,7 +18,7 @@ test = false
 [features]
 default = ["std"]
 std = ["phf_shared/std"]
-uncased = ["phf_shared/uncased"]
+uncased = ["phf_macros?/uncased", "phf_shared/uncased"]
 unicase = ["phf_macros?/unicase", "phf_shared/unicase"]
 macros = ["phf_macros"]
 

--- a/phf/examples/uncased-example/Cargo.toml
+++ b/phf/examples/uncased-example/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "unicase-example"
+name = "uncased-example"
 version = "0.1.0"
 edition = "2021"
 rust-version = "1.61"

--- a/phf/examples/uncased-example/Cargo.toml
+++ b/phf/examples/uncased-example/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "unicase-example"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.61"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+phf = { version = "^0.11.2", features = ["macros", "uncased"] }
+uncased = "0.9.7"

--- a/phf/examples/uncased-example/src/main.rs
+++ b/phf/examples/uncased-example/src/main.rs
@@ -1,0 +1,9 @@
+use phf::phf_map;
+use uncased::UncasedStr;
+
+pub static MAP: phf::Map<&'static UncasedStr, isize> = phf_map!(
+    UncasedStr::new("Foo") => 0,
+    UncasedStr::new("Bar") => 1,
+);
+
+fn main() {}

--- a/phf_codegen/test/Cargo.toml
+++ b/phf_codegen/test/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2021"
 
 [dependencies]
 phf = { version = "^0.11.2", features = ["uncased", "unicase"] }
-uncased = { version = "0.9.6", default-features = false }
+uncased = { version = "0.9.7", default-features = false }
 unicase = "2.4.0"
 
 [build-dependencies]
 phf_codegen = { version = "^0.11.2", path = ".." }
 unicase = "2.4.0"
-uncased = { version = "0.9.6", default-features = false }
+uncased = { version = "0.9.7", default-features = false }

--- a/phf_macros/Cargo.toml
+++ b/phf_macros/Cargo.toml
@@ -15,12 +15,14 @@ proc-macro = true
 
 [features]
 unicase = ["unicase_", "phf_shared/unicase"]
+uncased = ["uncased_", "phf_shared/uncased"]
 
 [dependencies]
 syn = { version = "2", features = ["full"] }
 quote = "1"
 proc-macro2 = "1"
 unicase_ = { package = "unicase", version = "2.4.0", optional = true }
+uncased_ = { package = "uncased", version = "0.9.7", optional = true }
 
 phf_generator = "0.11.1"
 phf_shared = { version = "^0.11.2", default-features = false }

--- a/phf_macros/src/lib.rs
+++ b/phf_macros/src/lib.rs
@@ -156,7 +156,13 @@ impl ParsedKey {
                     return None;
                 }
 
-                let _value = match call.args.first().unwrap() {
+                let mut arg = call.args.first().unwrap();
+
+                while let Expr::Group(group) = arg {
+                    arg = &group.expr;
+                }
+
+                let _value = match arg {
                     Expr::Lit(ExprLit {
                         attrs: _,
                         lit: Lit::Str(s),

--- a/phf_macros_tests/Cargo.toml
+++ b/phf_macros_tests/Cargo.toml
@@ -14,5 +14,6 @@ categories = ["data-structures"]
 [dev-dependencies]
 trybuild = "1.0"
 phf = { version = "0.11", features = ["macros"] }
-phf_macros = { version = "0.11", features = ["unicase"] }
+phf_macros = { version = "0.11", features = ["unicase", "uncased"] }
 unicase = "2.4.0"
+uncased = "0.9.7"

--- a/phf_macros_tests/tests/compile-fail-uncased/equivalent-keys.rs
+++ b/phf_macros_tests/tests/compile-fail-uncased/equivalent-keys.rs
@@ -1,0 +1,9 @@
+use phf::phf_map;
+use uncased::UncasedStr;
+
+static MAP: phf::Map<&'static UncasedStr, isize> = phf_map!(
+    UncasedStr::new("FOO") => 42,
+    UncasedStr::new("foo") => 42, //~ ERROR duplicate key UncasedStr("FOO")
+);
+
+fn main() {}

--- a/phf_macros_tests/tests/compile-fail-uncased/equivalent-keys.stderr
+++ b/phf_macros_tests/tests/compile-fail-uncased/equivalent-keys.stderr
@@ -1,0 +1,5 @@
+error: duplicate key
+ --> tests/compile-fail-uncased/equivalent-keys.rs:6:5
+  |
+6 |     UncasedStr::new("foo") => 42, //~ ERROR duplicate key UncasedStr("FOO")
+  |     ^^^^^^^^^^^^^^^^^^^^^^

--- a/phf_macros_tests/tests/test.rs
+++ b/phf_macros_tests/tests/test.rs
@@ -256,6 +256,18 @@ mod map {
         assert!(Some(&11) == MAP.get(&UniCase::new("bar")));
         assert_eq!(None, MAP.get(&UniCase::new("asdf")));
     }
+
+    #[test]
+    fn test_uncased() {
+        use uncased::UncasedStr;
+        static MAP: phf::Map<&'static UncasedStr, isize> = phf_map!(
+            UncasedStr::new("FOO") => 10,
+            UncasedStr::new("Bar") => 11,
+        );
+        assert!(Some(&10) == MAP.get("FOo".into()));
+        assert!(Some(&11) == MAP.get("bar".into()));
+        assert_eq!(None, MAP.get("asdf".into()));
+    }
 }
 
 mod set {

--- a/phf_macros_tests/tests/trybuild.rs
+++ b/phf_macros_tests/tests/trybuild.rs
@@ -11,6 +11,13 @@ fn compile_test_unicase() {
 
 #[test]
 #[ignore]
+fn compile_test_uncased() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/compile-fail-uncased/*.rs");
+}
+
+#[test]
+#[ignore]
 fn compile_fail() {
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/compile-fail/*.rs");


### PR DESCRIPTION
As the title says, macro support for uncased, since `UncasedStr::new` is const now.
Tests and examples matching the existing ones for Unicase are included.
I wrote this before noticing that #289 includes the same feature, and either will do, but I'm hoping a more focused PR has a better chance of getting merged.