### PR TITLE
Update rand to 0.9 and bump MSRV to 1.63

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         # MSRV and nightly
-        version: [1.61.0, stable, nightly]
+        version: [1.63.0, stable, nightly]
     steps:
       - uses: actions/checkout@v4
 
@@ -25,17 +25,17 @@ jobs:
       - uses: Swatinem/rust-cache@v2.7.7
 
       - name: Rustfmt check
-        if: matrix.version == '1.61.0'
+        if: matrix.version == '1.63.0'
         run: |
           rustup component add rustfmt
           cargo fmt --all -- --check
 
       - name: Run `cargo test` on workspace
-        if: matrix.version != '1.61.0'
+        if: matrix.version != '1.63.0'
         run: cargo test --workspace --exclude=phf_codegen_test
 
       - name: phf_codegen test
-        if: matrix.version != '1.61.0'
+        if: matrix.version != '1.63.0'
         run: cargo test -p phf_codegen_test
 
       - name: no_std build check

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It currently uses the
 [CHD algorithm](http://cmph.sourceforge.net/papers/esa09.pdf) and can generate
 a 100,000 entry map in roughly .4 seconds.
 
-MSRV (minimum supported rust version) is Rust 1.61.
+MSRV (minimum supported rust version) is Rust 1.63.
 
 ## Usage
 

--- a/phf/Cargo.toml
+++ b/phf/Cargo.toml
@@ -7,7 +7,7 @@ description = "Runtime support for perfect hash function data structures"
 repository = "https://github.com/rust-phf/rust-phf"
 edition = "2021"
 readme = "../README.md"
-rust-version = "1.61"
+rust-version = "1.63"
 categories = ["data-structures", "no-std"]
 
 [lib]

--- a/phf/examples/unicase-example/Cargo.toml
+++ b/phf/examples/unicase-example/Cargo.toml
@@ -2,7 +2,7 @@
 name = "unicase-example"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.61"
+rust-version = "1.63"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/phf/src/lib.rs
+++ b/phf/src/lib.rs
@@ -5,7 +5,7 @@
 //! [CHD algorithm](http://cmph.sourceforge.net/papers/esa09.pdf) and can generate
 //! a 100,000 entry map in roughly .4 seconds.
 //!
-//! MSRV (minimum supported rust version) is Rust 1.61.
+//! MSRV (minimum supported rust version) is Rust 1.63.
 //!
 //! ## Usage
 //!

--- a/phf_codegen/Cargo.toml
+++ b/phf_codegen/Cargo.toml
@@ -7,7 +7,7 @@ description = "Codegen library for PHF types"
 repository = "https://github.com/rust-phf/rust-phf"
 edition = "2021"
 readme = "../README.md"
-rust-version = "1.61"
+rust-version = "1.63"
 categories = ["data-structures"]
 
 [dependencies]

--- a/phf_generator/Cargo.toml
+++ b/phf_generator/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 description = "PHF generation logic"
 repository = "https://github.com/rust-phf/rust-phf"
 edition = "2021"
-rust-version = "1.61"
+rust-version = "1.63"
 categories = ["data-structures"]
 readme = "README.md"
 

--- a/phf_generator/Cargo.toml
+++ b/phf_generator/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["data-structures"]
 readme = "README.md"
 
 [dependencies]
-rand = { version = "0.8", default-features = false, features = ["small_rng"] }
+rand = { version = "0.9.0", default-features = false, features = ["small_rng"] }
 phf_shared = { version = "^0.11.2", default-features = false }
 # for stable black_box()
 criterion = { version = "0.3.6", optional = true }

--- a/phf_generator/benches/benches.rs
+++ b/phf_generator/benches/benches.rs
@@ -1,7 +1,7 @@
 use criterion::measurement::Measurement;
 use criterion::{criterion_group, criterion_main, Bencher, BenchmarkId, Criterion};
 
-use rand::distributions::Standard;
+use rand::distr::StandardUniform;
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
 
@@ -9,7 +9,7 @@ use phf_generator::generate_hash;
 
 fn gen_vec(len: usize) -> Vec<u64> {
     SmallRng::seed_from_u64(0xAAAAAAAAAAAAAAAA)
-        .sample_iter(Standard)
+        .sample_iter(StandardUniform)
         .take(len)
         .collect()
 }

--- a/phf_generator/src/lib.rs
+++ b/phf_generator/src/lib.rs
@@ -4,7 +4,7 @@
 
 #![doc(html_root_url = "https://docs.rs/phf_generator/0.11")]
 use phf_shared::{HashKey, Hashes, PhfHash};
-use rand::distributions::Standard;
+use rand::distr::StandardUniform;
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
 
@@ -29,7 +29,7 @@ where
     let mut generator = Generator::new(entries.len());
 
     SmallRng::seed_from_u64(FIXED_SEED)
-        .sample_iter(Standard)
+        .sample_iter(StandardUniform)
         .find(|key| {
             let hashes = entries.iter().map(|entry| hash_fn(entry, key));
             generator.reset(hashes);

--- a/phf_macros/Cargo.toml
+++ b/phf_macros/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 description = "Macros to generate types in the phf crate"
 repository = "https://github.com/rust-phf/rust-phf"
 readme = "../README.md"
-rust-version = "1.61"
+rust-version = "1.63"
 categories = ["data-structures"]
 
 [lib]

--- a/phf_macros_tests/Cargo.toml
+++ b/phf_macros_tests/Cargo.toml
@@ -3,7 +3,7 @@ name = "phf_macros_tests"
 version = "0.1.0"
 authors = ["Yuki Okushi <jtitor@2k36.org>"]
 edition = "2021"
-rust-version = "1.61"
+rust-version = "1.63"
 repository = "https://github.com/rust-phf/rust-phf"
 categories = ["data-structures"]
 

--- a/phf_shared/Cargo.toml
+++ b/phf_shared/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 description = "Support code shared by PHF libraries"
 repository = "https://github.com/rust-phf/rust-phf"
 edition = "2021"
-rust-version = "1.61"
+rust-version = "1.63"
 categories = ["data-structures"]
 readme = "README.md"
 


### PR DESCRIPTION
The MSRV bump is due to rand 0.9 having an MSRV of 1.63, which seems to be the MSRV most "foundational" crates are settling on for the time being.