### PR TITLE
bidirectional map

### DIFF
--- a/phf/src/bi_map.rs
+++ b/phf/src/bi_map.rs
@@ -1,0 +1,351 @@
+//! An immutable map constructed at compile time.
+use core::fmt;
+use core::iter::FusedIterator;
+use core::iter::IntoIterator;
+use core::slice;
+use phf_shared::{self, HashKey, PhfBorrow, PhfHash};
+#[cfg(feature = "serde")]
+use serde::ser::{Serialize, SerializeMap, Serializer};
+
+/// An immutable bidirectional-map constructed at compile time.
+///
+/// ## Note
+///
+/// The fields of this struct are public so that they may be initialized by the
+/// `phf_map!` macro and code generation. They are subject to change at any
+/// time and should never be accessed directly.
+pub struct BiMap<L: 'static, R: 'static> {
+    #[doc(hidden)]
+    pub key0: HashKey,
+    #[doc(hidden)]
+    pub key1: HashKey,
+    #[doc(hidden)]
+    pub disps0: &'static [(u32, u32)],
+    #[doc(hidden)]
+    pub disps1: &'static [(u32, u32)],
+    #[doc(hidden)]
+    pub idxs0: &'static [usize],
+    #[doc(hidden)]
+    pub idxs1: &'static [usize],
+    #[doc(hidden)]
+    pub entries: &'static [(L, R)],
+}
+
+impl<L, R> fmt::Debug for BiMap<L, R>
+where
+    L: fmt::Debug,
+    R: fmt::Debug,
+{
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.debug_map().entries(self.entries()).finish()
+    }
+}
+
+impl<L, R> Default for BiMap<L, R> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<L, R> PartialEq for BiMap<L, R>
+where
+    L: PartialEq,
+    R: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.key0 == other.key0
+            && self.key1 == other.key1
+            && self.disps0 == other.disps0
+            && self.disps1 == other.disps1
+            && self.idxs0 == other.idxs0
+            && self.idxs1 == other.idxs1
+            && self.entries == other.entries
+    }
+}
+
+impl<L, R> Eq for BiMap<L, R>
+where
+    L: Eq,
+    R: Eq,
+{
+}
+
+impl<L, R> BiMap<L, R> {
+    /// Create a new, empty, immutable map.
+    #[inline]
+    pub const fn new() -> Self {
+        Self {
+            key0: 0,
+            key1: 0,
+            disps0: &[],
+            disps1: &[],
+            idxs0: &[],
+            idxs1: &[],
+            entries: &[],
+        }
+    }
+
+    /// Returns the number of entries in the `Map`.
+    #[inline]
+    pub const fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Returns true if the `Map` is empty.
+    #[inline]
+    pub const fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Determines if `key` is in the `Map`.
+    pub fn contains_left<T: ?Sized>(&self, key: &T) -> bool
+    where
+        T: Eq + PhfHash,
+        L: PhfBorrow<T>,
+    {
+        self.get_entry_by_left(key).is_some()
+    }
+
+    /// Determines if `key` is in the `Map`.
+    pub fn contains_right<T: ?Sized>(&self, key: &T) -> bool
+    where
+        T: Eq + PhfHash,
+        R: PhfBorrow<T>,
+    {
+        self.get_entry_by_right(key).is_some()
+    }
+
+    /// Like `get`, but returns both the key and the value.
+    pub fn get_entry_by_left<T: ?Sized>(&self, key: &T) -> Option<(&L, &R)>
+    where
+        T: Eq + PhfHash,
+        L: PhfBorrow<T>,
+    {
+        if self.disps0.is_empty() {
+            return None;
+        } //Prevent panic on empty map
+        let hashes = phf_shared::hash(key, &self.key0);
+        let idx_index = phf_shared::get_index(&hashes, self.disps0, self.entries.len());
+        let idx = self.idxs0[idx_index as usize];
+        let entry = &self.entries[idx];
+
+        let b: &T = entry.0.borrow();
+        if b == key {
+            Some((&entry.0, &entry.1))
+        } else {
+            None
+        }
+    }
+
+    /// Like `get`, but returns both the key and the value.
+    pub fn get_entry_by_right<T: ?Sized>(&self, key: &T) -> Option<(&L, &R)>
+    where
+        T: Eq + PhfHash,
+        R: PhfBorrow<T>,
+    {
+        if self.disps0.is_empty() {
+            return None;
+        } //Prevent panic on empty map
+        let hashes = phf_shared::hash(key, &self.key1);
+        let idx_index = phf_shared::get_index(&hashes, self.disps1, self.entries.len());
+        let idx = self.idxs1[idx_index as usize];
+        let entry = &self.entries[idx];
+
+        let b: &T = entry.1.borrow();
+        if b == key {
+            Some((&entry.0, &entry.1))
+        } else {
+            None
+        }
+    }
+
+    /// Returns an iterator over the key/value pairs in the map.
+    ///
+    /// Entries are returned in an arbitrary but fixed order.
+    pub fn entries(&self) -> Entries<'_, L, R> {
+        Entries {
+            iter: self.entries.iter(),
+        }
+    }
+
+    /// Returns an iterator over the keys in the map.
+    ///
+    /// Keys are returned in an arbitrary but fixed order.
+    pub fn left_entries(&self) -> LeftEntries<'_, L, R> {
+        LeftEntries {
+            iter: self.entries(),
+        }
+    }
+
+    /// Returns an iterator over the values in the map.
+    ///
+    /// Values are returned in an arbitrary but fixed order.
+    pub fn right_entries(&self) -> RightEntries<'_, L, R> {
+        RightEntries {
+            iter: self.entries(),
+        }
+    }
+}
+
+impl<'a, L, R> IntoIterator for &'a BiMap<L, R> {
+    type Item = (&'a L, &'a R);
+    type IntoIter = Entries<'a, L, R>;
+
+    fn into_iter(self) -> Entries<'a, L, R> {
+        self.entries()
+    }
+}
+
+/// An iterator over the key/value pairs in a `Map`.
+pub struct Entries<'a, L, R> {
+    iter: slice::Iter<'a, (L, R)>,
+}
+
+impl<'a, L, R> Clone for Entries<'a, L, R> {
+    #[inline]
+    fn clone(&self) -> Self {
+        Self {
+            iter: self.iter.clone(),
+        }
+    }
+}
+
+impl<'a, L, R> fmt::Debug for Entries<'a, L, R>
+where
+    L: fmt::Debug,
+    R: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_list().entries(self.clone()).finish()
+    }
+}
+
+impl<'a, L, R> Iterator for Entries<'a, L, R> {
+    type Item = (&'a L, &'a R);
+
+    fn next(&mut self) -> Option<(&'a L, &'a R)> {
+        self.iter.next().map(|&(ref k, ref v)| (k, v))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+}
+
+impl<'a, L, R> DoubleEndedIterator for Entries<'a, L, R> {
+    fn next_back(&mut self) -> Option<(&'a L, &'a R)> {
+        self.iter.next_back().map(|e| (&e.0, &e.1))
+    }
+}
+
+impl<'a, L, R> ExactSizeIterator for Entries<'a, L, R> {}
+
+impl<'a, L, R> FusedIterator for Entries<'a, L, R> {}
+
+/// An iterator over the keys in a `Map`.
+pub struct LeftEntries<'a, L, R> {
+    iter: Entries<'a, L, R>,
+}
+
+impl<'a, L, R> Clone for LeftEntries<'a, L, R> {
+    #[inline]
+    fn clone(&self) -> Self {
+        Self {
+            iter: self.iter.clone(),
+        }
+    }
+}
+
+impl<'a, L, R> fmt::Debug for LeftEntries<'a, L, R>
+where
+    L: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_list().entries(self.clone()).finish()
+    }
+}
+
+impl<'a, L, R> Iterator for LeftEntries<'a, L, R> {
+    type Item = &'a L;
+
+    fn next(&mut self) -> Option<&'a L> {
+        self.iter.next().map(|e| e.0)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+}
+
+impl<'a, L, R> DoubleEndedIterator for LeftEntries<'a, L, R> {
+    fn next_back(&mut self) -> Option<&'a L> {
+        self.iter.next_back().map(|e| e.0)
+    }
+}
+
+impl<'a, L, R> ExactSizeIterator for LeftEntries<'a, L, R> {}
+
+impl<'a, L, R> FusedIterator for LeftEntries<'a, L, R> {}
+
+/// An iterator over the values in a `Map`.
+pub struct RightEntries<'a, L, R> {
+    iter: Entries<'a, L, R>,
+}
+
+impl<'a, L, R> Clone for RightEntries<'a, L, R> {
+    #[inline]
+    fn clone(&self) -> Self {
+        Self {
+            iter: self.iter.clone(),
+        }
+    }
+}
+
+impl<'a, L, R> fmt::Debug for RightEntries<'a, L, R>
+where
+    R: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_list().entries(self.clone()).finish()
+    }
+}
+
+impl<'a, L, R> Iterator for RightEntries<'a, L, R> {
+    type Item = &'a R;
+
+    fn next(&mut self) -> Option<&'a R> {
+        self.iter.next().map(|e| e.1)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+}
+
+impl<'a, L, R> DoubleEndedIterator for RightEntries<'a, L, R> {
+    fn next_back(&mut self) -> Option<&'a R> {
+        self.iter.next_back().map(|e| e.1)
+    }
+}
+
+impl<'a, L, R> ExactSizeIterator for RightEntries<'a, L, R> {}
+
+impl<'a, L, R> FusedIterator for RightEntries<'a, L, R> {}
+
+#[cfg(feature = "serde")]
+impl<L, R> Serialize for BiMap<L, R>
+where
+    L: Serialize,
+    R: Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut map = serializer.serialize_map(Some(self.len()))?;
+        for (l, r) in self.entries() {
+            map.serialize_entry(l, r)?;
+        }
+        map.end()
+    }
+}

--- a/phf/src/lib.rs
+++ b/phf/src/lib.rs
@@ -137,6 +137,8 @@ pub use phf_macros::phf_set;
 pub use phf_macros::phf_ordered_set;
 
 #[doc(inline)]
+pub use self::bi_map::BiMap;
+#[doc(inline)]
 pub use self::map::Map;
 #[doc(inline)]
 pub use self::ordered_map::OrderedMap;
@@ -146,6 +148,7 @@ pub use self::ordered_set::OrderedSet;
 pub use self::set::Set;
 pub use phf_shared::PhfHash;
 
+pub mod bi_map;
 pub mod map;
 pub mod ordered_map;
 pub mod ordered_set;

--- a/phf_macros/src/lib.rs
+++ b/phf_macros/src/lib.rs
@@ -241,6 +241,20 @@ impl Parse for Entry {
     }
 }
 
+struct BiEntry {
+    left: Key,
+    right: Key,
+}
+
+impl Parse for BiEntry {
+    fn parse(input: ParseStream<'_>) -> parse::Result<BiEntry> {
+        let left = input.parse()?;
+        input.parse::<Token![=>]>()?;
+        let right = input.parse()?;
+        Ok(BiEntry { left, right })
+    }
+}
+
 struct Map(Vec<Entry>);
 
 impl Parse for Map {
@@ -249,6 +263,17 @@ impl Parse for Map {
         let map = parsed.into_iter().collect::<Vec<_>>();
         check_duplicates(&map)?;
         Ok(Map(map))
+    }
+}
+
+struct BiMap(Vec<BiEntry>);
+
+impl Parse for BiMap {
+    fn parse(input: ParseStream<'_>) -> parse::Result<BiMap> {
+        let parsed = Punctuated::<BiEntry, Token![,]>::parse_terminated(input)?;
+        let map = parsed.into_iter().collect::<Vec<_>>();
+        check_bi_duplicates(&map)?;
+        Ok(BiMap(map))
     }
 }
 
@@ -279,6 +304,20 @@ fn check_duplicates(entries: &[Entry]) -> parse::Result<()> {
     Ok(())
 }
 
+fn check_bi_duplicates(entries: &[BiEntry]) -> parse::Result<()> {
+    let mut left = HashSet::new();
+    let mut right = HashSet::new();
+    for entry in entries {
+        if !left.insert(&entry.left.parsed) {
+            return Err(Error::new_spanned(&entry.left.expr, "duplicate left"));
+        }
+        if !right.insert(&entry.right.parsed) {
+            return Err(Error::new_spanned(&entry.right.expr, "duplicate right"));
+        }
+    }
+    Ok(())
+}
+
 fn build_map(entries: &[Entry], state: HashState) -> proc_macro2::TokenStream {
     let key = state.key;
     let disps = state.disps.iter().map(|&(d1, d2)| quote!((#d1, #d2)));
@@ -292,6 +331,38 @@ fn build_map(entries: &[Entry], state: HashState) -> proc_macro2::TokenStream {
         phf::Map {
             key: #key,
             disps: &[#(#disps),*],
+            entries: &[#(#entries),*],
+        }
+    }
+}
+
+fn build_bimap(
+    entries: &[BiEntry],
+    state_left: HashState,
+    state_right: HashState,
+) -> proc_macro2::TokenStream {
+    let key0 = state_left.key;
+    let disps0 = state_left.disps.iter().map(|&(d1, d2)| quote!((#d1, #d2)));
+    let idxs0 = state_left.map.iter().map(|idx| quote!(#idx));
+
+    let key1 = state_right.key;
+    let disps1 = state_right.disps.iter().map(|&(d1, d2)| quote!((#d1, #d2)));
+    let idxs1 = state_right.map.iter().map(|idx| quote!(#idx));
+
+    let entries = entries.iter().map(|entry| {
+        let key = &entry.left.expr;
+        let value = &entry.right.expr;
+        quote!((#key, #value))
+    });
+
+    quote! {
+        phf::BiMap {
+            key0: #key0,
+            key1: #key1,
+            disps0: &[#(#disps0),*],
+            disps1: &[#(#disps1),*],
+            idxs0: &[#(#idxs0),*],
+            idxs1: &[#(#idxs1),*],
             entries: &[#(#entries),*],
         }
     }
@@ -315,6 +386,17 @@ fn build_ordered_map(entries: &[Entry], state: HashState) -> proc_macro2::TokenS
             entries: &[#(#entries),*],
         }
     }
+}
+
+#[proc_macro]
+pub fn phf_bimap(input: TokenStream) -> TokenStream {
+    let map = parse_macro_input!(input as BiMap);
+    let state_left =
+        phf_generator::generate_hash(&map.0.iter().map(|x| &x.left).collect::<Vec<_>>());
+    let state_right =
+        phf_generator::generate_hash(&map.0.iter().map(|x| &x.right).collect::<Vec<_>>());
+
+    build_bimap(&map.0, state_left, state_right).into()
 }
 
 #[proc_macro]

--- a/phf_macros_tests/tests/test.rs
+++ b/phf_macros_tests/tests/test.rs
@@ -561,3 +561,23 @@ mod ordered_set {
         }
     }
 }
+
+mod bi_map {
+    use phf_macros::phf_bimap;
+
+    #[test]
+    fn test() {
+        static MAP: phf::BiMap<&'static str, i32> = phf_bimap!(
+            "foo" => 10_i32,
+            "bar" => 11_i32,
+        );
+
+        assert_eq!(Some((&"foo", &10)), MAP.get_entry_by_left("foo"));
+        assert_eq!(Some((&"bar", &11)), MAP.get_entry_by_left("bar"));
+        assert_eq!(None, MAP.get_entry_by_left("xyz"));
+
+        assert_eq!(Some((&"foo", &10)), MAP.get_entry_by_right(&10));
+        assert_eq!(Some((&"bar", &11)), MAP.get_entry_by_right(&11));
+        assert_eq!(None, MAP.get_entry_by_right(&2));
+    }
+}


### PR DESCRIPTION
Implements bidirectional map, fixes #278.

I'm not interested in driving this forward, as I don't have a need for it. But since the issue said PRs welcome, I thought I'd at least kick it off for someone else to take over :)

This implementation might not be the best. It's currently based on 2-orderedmaps but de-duplicates the entries. Inspired by https://docs.rs/bimap/latest/bimap/index.html I used the `left`/`right` terminology instead of `key` and `value`.