### PR TITLE
perf(all): Optimize modulo operations for ~5% faster lookups and ~10% faster generator

### DIFF
--- a/phf/Cargo.toml
+++ b/phf/Cargo.toml
@@ -27,6 +27,15 @@ phf_macros = { version = "^0.13.1", optional = true, path = "../phf_macros" }
 phf_shared = { version = "^0.13.1", default-features = false, path = "../phf_shared" }
 serde = { version = "1.0", default-features = false, optional = true }
 
+[dev-dependencies]
+criterion = "0.6.0"
+fastrand = "2.3.0"
+phf_generator = "0.13.1"
+
+[[bench]]
+name = "benches"
+harness = false
+
 [package.metadata.docs.rs]
 features = ["macros"]
 

--- a/phf/benches/benches.rs
+++ b/phf/benches/benches.rs
@@ -1,0 +1,124 @@
+use criterion::{criterion_group, criterion_main, Bencher, BenchmarkId, Criterion};
+use phf::{Map, Set};
+use phf_shared::{displace, hash, FastModulo, HashKey, PhfHash};
+use std::borrow::Borrow;
+use std::hint::black_box;
+use std::time::Duration;
+
+// --- Baseline Implementation ---
+mod baseline {
+    use super::*;
+
+    pub struct Set<K: 'static> {
+        pub key: HashKey,
+        pub disps: &'static [(u32, u32)],
+        pub entries: &'static [(K, ())],
+    }
+
+    impl<K: PhfHash + Eq> Set<K> {
+        pub fn contains<T>(&self, key: &T) -> bool
+        where
+            K: Borrow<T>,
+            T: PhfHash + Eq + ?Sized,
+        {
+            if self.disps.is_empty() {
+                return false;
+            }
+
+            let hashes = hash(key, &self.key);
+            let (d1, d2) = self.disps[(hashes.g % self.disps.len() as u32) as usize];
+            let index = displace(hashes.f1, hashes.f2, d1, d2) % self.entries.len() as u32;
+
+            let entry: &T = self.entries[index as usize].0.borrow();
+            entry == key
+        }
+    }
+}
+
+fn gen_vec(size: usize) -> Vec<u64> {
+    let mut rng = fastrand::Rng::with_seed(12345);
+    (0..size).map(|_| rng.u64(..)).collect()
+}
+
+struct PhfData {
+    key: HashKey,
+    disps: &'static [(u32, u32)],
+    entries: &'static [(u64, ())],
+}
+
+fn setup_phf_data(vec: &[u64]) -> PhfData {
+    let state = phf_generator::generate_hash(vec);
+    let entries_vec: Vec<_> = state.map.iter().map(|&idx| (vec[idx], ())).collect();
+
+    PhfData {
+        key: state.key,
+        disps: Box::leak(state.disps.into_boxed_slice()),
+        entries: Box::leak(entries_vec.into_boxed_slice()),
+    }
+}
+
+fn bench_lookup_baseline(b: &mut Bencher, data: &(Vec<u64>, PhfData)) {
+    let (vec, phf_data) = data;
+    let set = baseline::Set {
+        key: phf_data.key,
+        disps: phf_data.disps,
+        entries: phf_data.entries,
+    };
+
+    b.iter(|| {
+        for key in vec {
+            black_box(set.contains(key));
+        }
+    });
+}
+
+fn bench_lookup_experiment(b: &mut Bencher, data: &(Vec<u64>, PhfData)) {
+    let (vec, phf_data) = data;
+    let set = Set {
+        map: Map {
+            key: phf_data.key,
+            disps: phf_data.disps,
+            entries: phf_data.entries,
+            disps_len: FastModulo::new(phf_data.disps.len() as u32),
+            entries_len: FastModulo::new(phf_data.entries.len() as u32),
+        },
+    };
+
+    b.iter(|| {
+        for key in vec {
+            black_box(set.contains(key));
+        }
+    });
+}
+
+fn compare_lookups(c: &mut Criterion) {
+    let mut group = c.benchmark_group("phf_lookup_hot_path");
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(3));
+
+    let sizes = vec![
+        1, 2, 5, 10, 25, 50, 75, 100, 250, 500, 1000, 2500, 5000, 7500, 10_000, 25_000, 50_000,
+        75_000, 100_000, 250_000, 500_000, 750_000, 1_000_000,
+    ];
+
+    for size in &sizes {
+        let vec = gen_vec(*size);
+        let phf_data = setup_phf_data(&vec);
+        let bench_data = (vec, phf_data);
+
+        group.bench_with_input(
+            BenchmarkId::new("baseline_lookup", size),
+            &bench_data,
+            bench_lookup_baseline,
+        );
+        group.bench_with_input(
+            BenchmarkId::new("experiment_lookup", size),
+            &bench_data,
+            bench_lookup_experiment,
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(benches, compare_lookups);
+criterion_main!(benches);

--- a/phf/src/lib.rs
+++ b/phf/src/lib.rs
@@ -188,6 +188,8 @@ pub use self::ordered_map::OrderedMap;
 pub use self::ordered_set::OrderedSet;
 #[doc(inline)]
 pub use self::set::Set;
+#[doc(hidden)]
+pub use phf_shared::FastModulo;
 pub use phf_shared::PhfHash;
 
 pub mod map;

--- a/phf/src/ordered_map.rs
+++ b/phf/src/ordered_map.rs
@@ -4,7 +4,7 @@ use core::iter::FusedIterator;
 use core::iter::IntoIterator;
 use core::ops::Index;
 use core::slice;
-use phf_shared::{self, HashKey, PhfBorrow, PhfHash};
+use phf_shared::{self, FastModulo, HashKey, PhfBorrow, PhfHash};
 
 /// An order-preserving immutable map constructed at compile time.
 ///
@@ -22,7 +22,11 @@ pub struct OrderedMap<K: 'static, V: 'static> {
     #[doc(hidden)]
     pub disps: &'static [(u32, u32)],
     #[doc(hidden)]
+    pub disps_len: FastModulo,
+    #[doc(hidden)]
     pub idxs: &'static [usize],
+    #[doc(hidden)]
+    pub idxs_len: FastModulo,
     #[doc(hidden)]
     pub entries: &'static [(K, V)],
 }
@@ -146,7 +150,7 @@ impl<K, V> OrderedMap<K, V> {
             return None;
         } //Prevent panic on empty map
         let hashes = phf_shared::hash(key, &self.key);
-        let idx_index = phf_shared::get_index(&hashes, self.disps, self.idxs.len());
+        let idx_index = phf_shared::get_index(&hashes, self.disps, self.idxs_len, self.disps_len);
         let idx = self.idxs[idx_index as usize];
         let entry = &self.entries[idx];
 

--- a/phf_codegen/src/lib.rs
+++ b/phf_codegen/src/lib.rs
@@ -139,7 +139,7 @@
 #![doc(html_root_url = "https://docs.rs/phf_codegen/0.13.1")]
 #![allow(clippy::new_without_default)]
 
-use phf_shared::{FmtConst, PhfHash};
+use phf_shared::{FastModulo, FmtConst, PhfHash};
 use std::borrow::Cow;
 use std::collections::HashSet;
 use std::fmt;
@@ -212,12 +212,16 @@ impl<'a, K: Hash + PhfHash + Eq + FmtConst> Map<'a, K> {
         }
 
         let state = phf_generator::generate_hash(&self.keys);
+        let disps_len = FastModulo::new(state.disps.len() as u32);
+        let entries_len = FastModulo::new(self.keys.len() as u32);
 
         DisplayMap {
             state,
             path: &self.path,
             keys: &self.keys,
             values: &self.values,
+            disps_len,
+            entries_len,
         }
     }
 }
@@ -228,6 +232,8 @@ pub struct DisplayMap<'a, K> {
     state: HashState,
     keys: &'a [K],
     values: &'a [Cow<'a, str>],
+    disps_len: FastModulo,
+    entries_len: FastModulo,
 }
 
 impl<'a, K: FmtConst + 'a> fmt::Display for DisplayMap<'a, K> {
@@ -273,7 +279,10 @@ impl<'a, K: FmtConst + 'a> fmt::Display for DisplayMap<'a, K> {
             f,
             "
     ],
-}}"
+    disps_len: {},
+    entries_len: {},
+}}",
+            self.disps_len, self.entries_len
         )
     }
 }
@@ -387,12 +396,16 @@ impl<'a, K: Hash + PhfHash + Eq + FmtConst> OrderedMap<'a, K> {
         }
 
         let state = phf_generator::generate_hash(&self.keys);
+        let disps_len = FastModulo::new(state.disps.len() as u32);
+        let idxs_len = FastModulo::new(self.keys.len() as u32);
 
         DisplayOrderedMap {
             state,
             path: &self.path,
             keys: &self.keys,
             values: &self.values,
+            disps_len,
+            idxs_len,
         }
     }
 }
@@ -403,6 +416,8 @@ pub struct DisplayOrderedMap<'a, K> {
     state: HashState,
     keys: &'a [K],
     values: &'a [Cow<'a, str>],
+    disps_len: FastModulo,
+    idxs_len: FastModulo,
 }
 
 impl<'a, K: FmtConst + 'a> fmt::Display for DisplayOrderedMap<'a, K> {
@@ -455,7 +470,10 @@ impl<'a, K: FmtConst + 'a> fmt::Display for DisplayOrderedMap<'a, K> {
             f,
             "
     ],
-}}"
+    disps_len: {},
+    idxs_len: {},
+}}",
+            self.disps_len, self.idxs_len
         )
     }
 }

--- a/phf_generator/benches/benches.rs
+++ b/phf_generator/benches/benches.rs
@@ -50,7 +50,186 @@ criterion_group!(
     gen_hash_small,
     gen_hash_med,
     gen_hash_large,
-    gen_hash_xlarge
+    gen_hash_xlarge,
+    compare_generators
 );
 
 criterion_main!(benches);
+
+fn compare_generators(c: &mut Criterion) {
+    let mut group = c.benchmark_group("codegen_comparison");
+    let sizes = vec![
+        0, 1, 2, 5, 10, 25, 50, 75, 100, 250, 500, 1000, 2500, 5000, 7500, 10_000, 25_000, 50_000,
+        75_000, 100_000, 250_000, 500_000, 750_000, 1_000_000,
+    ];
+
+    for size in &sizes {
+        group.bench_with_input(BenchmarkId::new("baseline", *size), size, bench_baseline);
+        group.bench_with_input(BenchmarkId::new("experiment", *size), size, bench_hash);
+    }
+    group.finish();
+}
+
+fn bench_baseline(b: &mut Bencher, len: &usize) {
+    let vec = gen_vec(*len);
+    b.iter(|| baseline::generate_hash(&vec))
+}
+
+mod baseline {
+    #![allow(dead_code)]
+
+    use std::iter;
+
+    use fastrand::Rng;
+    use phf_shared::{HashKey, Hashes, PhfHash};
+
+    const DEFAULT_LAMBDA: usize = 5;
+
+    const FIXED_SEED: u64 = 1234567890;
+
+    pub struct HashState {
+        pub key: HashKey,
+        pub disps: Vec<(u32, u32)>,
+        pub map: Vec<usize>,
+    }
+
+    pub fn generate_hash<H: PhfHash>(entries: &[H]) -> HashState {
+        generate_hash_with_hash_fn(entries, phf_shared::hash)
+    }
+
+    pub fn generate_hash_with_hash_fn<T, F>(entries: &[T], hash_fn: F) -> HashState
+    where
+        F: Fn(&T, &HashKey) -> Hashes,
+    {
+        let mut generator = Generator::new(entries.len());
+        let mut rng = Rng::with_seed(FIXED_SEED);
+
+        iter::repeat_with(|| rng.u64(..))
+            .find(|key| {
+                let hashes = entries.iter().map(|entry| hash_fn(entry, key));
+                generator.reset(hashes);
+
+                generator.try_generate_hash()
+            })
+            .map(|key| HashState {
+                key,
+                disps: generator.disps,
+                map: generator.map.into_iter().map(|i| i.unwrap()).collect(),
+            })
+            .expect("failed to solve PHF")
+    }
+
+    struct Bucket {
+        idx: usize,
+        keys: Vec<usize>,
+    }
+
+    struct Generator {
+        hashes: Vec<Hashes>,
+        buckets: Vec<Bucket>,
+        disps: Vec<(u32, u32)>,
+        map: Vec<Option<usize>>,
+        try_map: Vec<u64>,
+    }
+
+    impl Generator {
+        fn new(table_len: usize) -> Self {
+            let hashes = Vec::with_capacity(table_len);
+
+            let buckets_len = (table_len + DEFAULT_LAMBDA - 1) / DEFAULT_LAMBDA;
+            let buckets: Vec<_> = (0..buckets_len)
+                .map(|i| Bucket {
+                    idx: i,
+                    keys: vec![],
+                })
+                .collect();
+            let disps = vec![(0u32, 0u32); buckets_len];
+
+            let map = vec![None; table_len];
+            let try_map = vec![0u64; table_len];
+
+            Self {
+                hashes,
+                buckets,
+                disps,
+                map,
+                try_map,
+            }
+        }
+
+        fn reset<I>(&mut self, hashes: I)
+        where
+            I: Iterator<Item = Hashes>,
+        {
+            self.buckets.iter_mut().for_each(|b| b.keys.clear());
+            self.buckets.sort_by_key(|b| b.idx);
+            self.disps.iter_mut().for_each(|d| *d = (0, 0));
+            self.map.iter_mut().for_each(|m| *m = None);
+            self.try_map.iter_mut().for_each(|m| *m = 0);
+
+            self.hashes.clear();
+            self.hashes.extend(hashes);
+        }
+
+        fn try_generate_hash(&mut self) -> bool {
+            let buckets_len = self.buckets.len() as u32;
+            for (i, hash) in self.hashes.iter().enumerate() {
+                self.buckets[(hash.g % buckets_len) as usize].keys.push(i);
+            }
+
+            // Sort descending
+            self.buckets
+                .sort_by(|a, b| a.keys.len().cmp(&b.keys.len()).reverse());
+
+            let table_len = self.hashes.len();
+
+            // store whether an element from the bucket being placed is
+            // located at a certain position, to allow for efficient overlap
+            // checks. It works by storing the generation in each cell and
+            // each new placement-attempt is a new generation, so you can tell
+            // if this is legitimately full by checking that the generations
+            // are equal. (A u64 is far too large to overflow in a reasonable
+            // time for current hardware.)
+            let mut generation = 0u64;
+
+            // the actual values corresponding to the markers above, as
+            // (index, key) pairs, for adding to the main map once we've
+            // chosen the right disps.
+            let mut values_to_add = vec![];
+
+            'buckets: for bucket in &self.buckets {
+                for d1 in 0..(table_len as u32) {
+                    'disps: for d2 in 0..(table_len as u32) {
+                        values_to_add.clear();
+                        generation += 1;
+
+                        for &key in &bucket.keys {
+                            let idx = (phf_shared::displace(
+                                self.hashes[key].f1,
+                                self.hashes[key].f2,
+                                d1,
+                                d2,
+                            ) % (table_len as u32)) as usize;
+                            if self.map[idx].is_some() || self.try_map[idx] == generation {
+                                continue 'disps;
+                            }
+                            self.try_map[idx] = generation;
+                            values_to_add.push((idx, key));
+                        }
+
+                        // We've picked a good set of disps
+                        self.disps[bucket.idx] = (d1, d2);
+                        for &(idx, key) in &values_to_add {
+                            self.map[idx] = Some(key);
+                        }
+                        continue 'buckets;
+                    }
+                }
+
+                // Unable to find displacements for a bucket
+                return false;
+            }
+            true
+        }
+    }
+}

--- a/phf_generator/src/lib.rs
+++ b/phf_generator/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(likely_unlikely)]
 //! See [the `phf` crate's documentation][phf] for details.
 //!
 //! [phf]: https://docs.rs/phf
@@ -103,7 +102,9 @@ impl Generator {
 
     fn try_generate_hash(&mut self) -> bool {
         for (i, hash) in self.hashes.iter().enumerate() {
-            self.buckets[(hash.g % self.bucket_len) as usize].keys.push(i);
+            self.buckets[(hash.g % self.bucket_len) as usize]
+                .keys
+                .push(i);
         }
 
         // Sort descending

--- a/phf_macros/src/lib.rs
+++ b/phf_macros/src/lib.rs
@@ -431,12 +431,16 @@ fn build_map(entries: &[Entry], state: HashState) -> proc_macro2::TokenStream {
         // Don't include attributes since we've filtered at macro expansion time
         quote!((#key, #value))
     });
+    let disps_len = state.disps.len() as u32;
+    let entries_len = state.map.len() as u32;
 
     quote! {
         phf::Map {
             key: #key,
             disps: &[#(#disps),*],
             entries: &[#(#entries),*],
+            disps_len: phf::FastModulo::new(#disps_len),
+            entries_len: phf::FastModulo::new(#entries_len),
         }
     }
 }
@@ -451,6 +455,8 @@ fn build_ordered_map(entries: &[Entry], state: HashState) -> proc_macro2::TokenS
         // Don't include attributes since we've filtered at macro expansion time
         quote!((#key, #value))
     });
+    let disps_len = state.disps.len() as u32;
+    let idxs_len = state.map.len() as u32;
 
     quote! {
         phf::OrderedMap {
@@ -458,6 +464,8 @@ fn build_ordered_map(entries: &[Entry], state: HashState) -> proc_macro2::TokenS
             disps: &[#(#disps),*],
             idxs: &[#(#idxs),*],
             entries: &[#(#entries),*],
+            disps_len: phf::FastModulo::new(#disps_len),
+            idxs_len: phf::FastModulo::new(#idxs_len),
         }
     }
 }


### PR DESCRIPTION
## Summary
This PR optimizes the two hot-path modulo operations in phf map/set lookups and in phf_generator. It replaces thm with a faster, branchless algorithm based on the paper ["Faster Remainder by Direct Computation" by Lemire, Kaser, and Kurz](https://arxiv.org/abs/1902.01961).

The exhaustive search in the generator is slow, this changes replaces the expensive modulo on the hot path with 2 multiplications and one shift. Same can be said for runtime lookups.

## Performance Benchmarks
All benchmarks were run on an x86-64 CPU and are included in the benches/ directory for reproduction.

### Compile-Time: phf_generator Speed

| Input Size | Baseline (Standard `%`) | Experiment (Fast Modulo) | Improvement |
| :--- | :--- | :--- | :--- |
| 10 | 1.34 µs | 1.19 µs | **+11.2%** |
| 100 | 19.52 µs | 18.99 µs | **+2.7%** |
| 1,000 | 903.15 µs | 788.39 µs | **+12.7%** |
| 10,000 | 7.19 ms | 6.41 ms | **+10.8%** |
| 100,000 | 90.91 ms | 82.23 ms | **+9.5%** |
| 500,000 | 641.56 ms | 578.43 ms | **+9.8%** |
| 1,000,000 | 1.92 s | 1.75 s | **+8.9%** |

### Runtime: phf Lookup Speed

| Input Size | Baseline (Standard `%`) | Experiment (Fast Modulo) | Improvement |
| :--- | :--- | :--- | :--- |
| 10 | 103.88 ns | 100.50 ns | **~3.3%** |
| 100 | 1.01 µs | 0.99 µs | **~1.5%** |
| 1,000 | 10.00 µs | 9.82 µs | **~1.8%** |
| 10,000 | 104.02 µs | 101.89 µs | **~2.0%** |
| 100,000 | 1.24 ms | 1.18 ms | **~5.1%** |
| 500,000 | 9.29 ms | 8.87 ms | **~4.6%** |
| 1,000,000 | 22.83 ms | 21.69 ms | **~5.0%** |

## Alternative Approaches Considered

This is based on multiplication and a right-shift. But with this approach the generator was unable to find a collision-free displacement set, failing to build a map even for as few as 10 entries.

Link: [https://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/](https://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/)
```rust
fn index(hash: u32, range_len: u32) -> u32 {
    ((hash as u64 * range_len as u64) >> 32) as u32
}