### PR TITLE
feat: add experimental ptrhash feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Rust-PHF is a library to generate efficient lookup tables at compile time using
 [perfect hash functions](http://en.wikipedia.org/wiki/Perfect_hash_function).
 
 It currently uses the
-[CHD algorithm](http://cmph.sourceforge.net/papers/esa09.pdf) and can generate
-a 100,000 entry map in roughly .4 seconds.
+[CHD algorithm](http://cmph.sourceforge.net/papers/esa09.pdf) by default and
+also ships an experimental `ptrhash` feature for an alternative MPHF layout.
 
 MSRV (minimum supported rust version) is Rust 1.71.
 
@@ -72,6 +72,14 @@ pub fn parse_operator(operator: &str) -> Option<&'static str> {
 phf = { version = "0.13.1", features = ["macros"] }
 ```
 
+To try the experimental alternative, enable `ptrhash` on both the generator and
+runtime crates you use:
+
+```toml
+[dependencies]
+phf = { version = "0.13.1", features = ["macros", "ptrhash"] }
+```
+
 #### Note
 
 Currently, the macro syntax has some limitations and may not
@@ -88,6 +96,10 @@ To use `phf_codegen` on build.rs, you have to add dependencies under `[build-dep
 phf = { version = "0.13.1", default-features = false }
 phf_codegen = "0.13.1"
 ```
+
+When using the experimental `ptrhash` layout, enable the `ptrhash` feature on
+both `phf_codegen` and the runtime `phf` dependency so the generated constants
+match the runtime struct layout.
 
 Then put code on build.rs:
 

--- a/phf/Cargo.toml
+++ b/phf/Cargo.toml
@@ -21,6 +21,7 @@ std = ["phf_shared/std", "serde?/std"]
 uncased = ["phf_macros?/uncased", "phf_shared/uncased"]
 unicase = ["phf_macros?/unicase", "phf_shared/unicase"]
 macros = ["phf_macros"]
+ptrhash = ["phf_macros?/ptrhash", "phf_shared/ptrhash"]
 
 [dependencies]
 phf_macros = { version = "^0.13.1", optional = true, path = "../phf_macros" }

--- a/phf/src/lib.rs
+++ b/phf/src/lib.rs
@@ -2,8 +2,8 @@
 //! [perfect hash functions](http://en.wikipedia.org/wiki/Perfect_hash_function).
 //!
 //! It currently uses the
-//! [CHD algorithm](http://cmph.sourceforge.net/papers/esa09.pdf) and can generate
-//! a 100,000 entry map in roughly .4 seconds.
+//! [CHD algorithm](http://cmph.sourceforge.net/papers/esa09.pdf) by default and
+//! also ships an experimental `ptrhash` feature for an alternative MPHF layout.
 //!
 //! MSRV (minimum supported rust version) is Rust 1.71.
 //!
@@ -17,6 +17,15 @@
 //!```toml
 //! [dependencies]
 //! phf = { version = "0.13.1", features = ["macros"] }
+//! ```
+//!
+//! To try the experimental MPHF alternative instead of the default CHD layout,
+//! enable the `ptrhash` feature on every `phf` crate involved in generation and
+//! runtime lookup:
+//!
+//! ```toml
+//! [dependencies]
+//! phf = { version = "0.13.1", features = ["macros", "ptrhash"] }
 //! ```
 //!
 //! To compile the `phf` crate with a dependency on

--- a/phf/src/map.rs
+++ b/phf/src/map.rs
@@ -15,11 +15,31 @@ use serde::ser::{Serialize, SerializeMap, Serializer};
 /// The fields of this struct are public so that they may be initialized by the
 /// `phf_map!` macro and code generation. They are subject to change at any
 /// time and should never be accessed directly.
+#[cfg(not(feature = "ptrhash"))]
 pub struct Map<K: 'static, V: 'static> {
     #[doc(hidden)]
     pub key: HashKey,
     #[doc(hidden)]
     pub disps: &'static [(u32, u32)],
+    #[doc(hidden)]
+    pub entries: &'static [(K, V)],
+}
+
+/// An immutable map constructed at compile time.
+///
+/// ## Note
+///
+/// The fields of this struct are public so that they may be initialized by the
+/// `phf_map!` macro and code generation. They are subject to change at any
+/// time and should never be accessed directly.
+#[cfg(feature = "ptrhash")]
+pub struct Map<K: 'static, V: 'static> {
+    #[doc(hidden)]
+    pub key: HashKey,
+    #[doc(hidden)]
+    pub pilots: &'static [u8],
+    #[doc(hidden)]
+    pub remap: &'static [u32],
     #[doc(hidden)]
     pub entries: &'static [(K, V)],
 }
@@ -57,8 +77,17 @@ where
     K: PartialEq,
     V: PartialEq,
 {
+    #[cfg(not(feature = "ptrhash"))]
     fn eq(&self, other: &Self) -> bool {
         self.key == other.key && self.disps == other.disps && self.entries == other.entries
+    }
+
+    #[cfg(feature = "ptrhash")]
+    fn eq(&self, other: &Self) -> bool {
+        self.key == other.key
+            && self.pilots == other.pilots
+            && self.remap == other.remap
+            && self.entries == other.entries
     }
 }
 
@@ -73,11 +102,20 @@ impl<K, V> Map<K, V> {
     /// Create a new, empty, immutable map.
     #[inline]
     pub const fn new() -> Self {
-        Self {
+        #[cfg(not(feature = "ptrhash"))]
+        return Self {
             key: 0,
             disps: &[],
             entries: &[],
-        }
+        };
+
+        #[cfg(feature = "ptrhash")]
+        return Self {
+            key: 0,
+            pilots: &[],
+            remap: &[],
+            entries: &[],
+        };
     }
 
     /// Returns the number of entries in the `Map`.
@@ -123,6 +161,7 @@ impl<K, V> Map<K, V> {
     }
 
     /// Like `get`, but returns both the key and the value.
+    #[cfg(not(feature = "ptrhash"))]
     pub fn get_entry<T>(&self, key: &T) -> Option<(&K, &V)>
     where
         T: Eq + PhfHash + ?Sized,
@@ -136,6 +175,35 @@ impl<K, V> Map<K, V> {
         let entry = &self.entries[index as usize];
         let b: &T = entry.0.borrow();
         if b == key {
+            Some((&entry.0, &entry.1))
+        } else {
+            None
+        }
+    }
+
+    /// Like `get`, but returns both the key and the value.
+    #[cfg(feature = "ptrhash")]
+    pub fn get_entry<T>(&self, key: &T) -> Option<(&K, &V)>
+    where
+        T: Eq + PhfHash + ?Sized,
+        K: PhfBorrow<T>,
+    {
+        if self.entries.is_empty() {
+            return None;
+        }
+
+        let hash = phf_shared::ptrhash::hash(key, &self.key);
+        let index = phf_shared::ptrhash::get_index(
+            self.key,
+            hash,
+            self.pilots,
+            self.remap,
+            self.entries.len(),
+        );
+        let entry = &self.entries[index as usize];
+        let borrowed: &T = entry.0.borrow();
+
+        if borrowed == key {
             Some((&entry.0, &entry.1))
         } else {
             None

--- a/phf/src/ordered_map.rs
+++ b/phf/src/ordered_map.rs
@@ -16,11 +16,36 @@ use phf_shared::{self, HashKey, PhfBorrow, PhfHash};
 /// The fields of this struct are public so that they may be initialized by the
 /// `phf_ordered_map!` macro and code generation. They are subject to change at
 /// any time and should never be accessed directly.
+#[cfg(not(feature = "ptrhash"))]
 pub struct OrderedMap<K: 'static, V: 'static> {
     #[doc(hidden)]
     pub key: HashKey,
     #[doc(hidden)]
     pub disps: &'static [(u32, u32)],
+    #[doc(hidden)]
+    pub idxs: &'static [usize],
+    #[doc(hidden)]
+    pub entries: &'static [(K, V)],
+}
+
+/// An order-preserving immutable map constructed at compile time.
+///
+/// Unlike a `Map`, iteration order is guaranteed to match the definition
+/// order.
+///
+/// ## Note
+///
+/// The fields of this struct are public so that they may be initialized by the
+/// `phf_ordered_map!` macro and code generation. They are subject to change at
+/// any time and should never be accessed directly.
+#[cfg(feature = "ptrhash")]
+pub struct OrderedMap<K: 'static, V: 'static> {
+    #[doc(hidden)]
+    pub key: HashKey,
+    #[doc(hidden)]
+    pub pilots: &'static [u8],
+    #[doc(hidden)]
+    pub remap: &'static [u32],
     #[doc(hidden)]
     pub idxs: &'static [usize],
     #[doc(hidden)]
@@ -54,9 +79,19 @@ where
     K: PartialEq,
     V: PartialEq,
 {
+    #[cfg(not(feature = "ptrhash"))]
     fn eq(&self, other: &Self) -> bool {
         self.key == other.key
             && self.disps == other.disps
+            && self.idxs == other.idxs
+            && self.entries == other.entries
+    }
+
+    #[cfg(feature = "ptrhash")]
+    fn eq(&self, other: &Self) -> bool {
+        self.key == other.key
+            && self.pilots == other.pilots
+            && self.remap == other.remap
             && self.idxs == other.idxs
             && self.entries == other.entries
     }
@@ -142,19 +177,48 @@ impl<K, V> OrderedMap<K, V> {
         T: Eq + PhfHash + ?Sized,
         K: PhfBorrow<T>,
     {
-        if self.disps.is_empty() {
-            return None;
-        } //Prevent panic on empty map
-        let hashes = phf_shared::hash(key, &self.key);
-        let idx_index = phf_shared::get_index(&hashes, self.disps, self.idxs.len());
-        let idx = self.idxs[idx_index as usize];
-        let entry = &self.entries[idx];
+        #[cfg(not(feature = "ptrhash"))]
+        {
+            if self.disps.is_empty() {
+                return None;
+            }
 
-        let b: &T = entry.0.borrow();
-        if b == key {
-            Some((idx, (&entry.0, &entry.1)))
-        } else {
-            None
+            let hashes = phf_shared::hash(key, &self.key);
+            let idx_index = phf_shared::get_index(&hashes, self.disps, self.idxs.len());
+            let idx = self.idxs[idx_index as usize];
+            let entry = &self.entries[idx];
+
+            let borrowed: &T = entry.0.borrow();
+            if borrowed == key {
+                Some((idx, (&entry.0, &entry.1)))
+            } else {
+                None
+            }
+        }
+
+        #[cfg(feature = "ptrhash")]
+        {
+            if self.entries.is_empty() {
+                return None;
+            }
+
+            let hash = phf_shared::ptrhash::hash(key, &self.key);
+            let idx_index = phf_shared::ptrhash::get_index(
+                self.key,
+                hash,
+                self.pilots,
+                self.remap,
+                self.idxs.len(),
+            );
+            let idx = self.idxs[idx_index as usize];
+            let entry = &self.entries[idx];
+
+            let borrowed: &T = entry.0.borrow();
+            if borrowed == key {
+                Some((idx, (&entry.0, &entry.1)))
+            } else {
+                None
+            }
         }
     }
 

--- a/phf_codegen/Cargo.toml
+++ b/phf_codegen/Cargo.toml
@@ -10,6 +10,9 @@ readme = "../README.md"
 rust-version = "1.71"
 categories = ["data-structures"]
 
+[features]
+ptrhash = ["phf_generator/ptrhash"]
+
 [dependencies]
 phf_generator = "0.13.1"
 phf_shared = "0.13.1"

--- a/phf_codegen/src/lib.rs
+++ b/phf_codegen/src/lib.rs
@@ -19,6 +19,10 @@
 //! phf_codegen = "0.13.1"
 //! ```
 //!
+//! When using the experimental `ptrhash` feature, enable it on both
+//! `phf_codegen` and the runtime `phf` dependency so the generated constants
+//! and runtime layout stay in sync.
+//!
 //! Then put code on build.rs:
 //!
 //! ```ignore
@@ -145,6 +149,9 @@ use std::collections::HashSet;
 use std::fmt;
 use std::hash::Hash;
 
+#[cfg(feature = "ptrhash")]
+use phf_generator::ptrhash::HashState;
+#[cfg(not(feature = "ptrhash"))]
 use phf_generator::HashState;
 
 struct Delegate<T>(T);
@@ -152,6 +159,18 @@ struct Delegate<T>(T);
 impl<T: FmtConst> fmt::Display for Delegate<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt_const(f)
+    }
+}
+
+fn generate_hash_state<H: PhfHash>(keys: &[H]) -> HashState {
+    #[cfg(not(feature = "ptrhash"))]
+    {
+        phf_generator::generate_hash(keys)
+    }
+
+    #[cfg(feature = "ptrhash")]
+    {
+        phf_generator::ptrhash::generate_hash(keys)
     }
 }
 
@@ -211,7 +230,7 @@ impl<'a, K: Hash + PhfHash + Eq + FmtConst> Map<'a, K> {
             }
         }
 
-        let state = phf_generator::generate_hash(&self.keys);
+        let state = generate_hash_state(&self.keys);
 
         DisplayMap {
             state,
@@ -231,6 +250,7 @@ pub struct DisplayMap<'a, K> {
 }
 
 impl<'a, K: FmtConst + 'a> fmt::Display for DisplayMap<'a, K> {
+    #[cfg(not(feature = "ptrhash"))]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // funky formatting here for nice output
         write!(
@@ -259,6 +279,66 @@ impl<'a, K: FmtConst + 'a> fmt::Display for DisplayMap<'a, K> {
         )?;
 
         // write map entries
+        for &idx in &self.state.map {
+            write!(
+                f,
+                "
+        ({}, {}),",
+                Delegate(&self.keys[idx]),
+                &self.values[idx]
+            )?;
+        }
+
+        write!(
+            f,
+            "
+    ],
+}}"
+        )
+    }
+
+    #[cfg(feature = "ptrhash")]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}::Map {{
+    key: {:?},
+    pilots: &[",
+            self.path, self.state.seed
+        )?;
+
+        for &pilot in &self.state.pilots {
+            write!(
+                f,
+                "
+        {},",
+                pilot
+            )?;
+        }
+
+        write!(
+            f,
+            "
+    ],
+    remap: &[",
+        )?;
+
+        for &index in &self.state.remap {
+            write!(
+                f,
+                "
+        {},",
+                index
+            )?;
+        }
+
+        write!(
+            f,
+            "
+    ],
+    entries: &[",
+        )?;
+
         for &idx in &self.state.map {
             write!(
                 f,
@@ -386,7 +466,7 @@ impl<'a, K: Hash + PhfHash + Eq + FmtConst> OrderedMap<'a, K> {
             }
         }
 
-        let state = phf_generator::generate_hash(&self.keys);
+        let state = generate_hash_state(&self.keys);
 
         DisplayOrderedMap {
             state,
@@ -406,6 +486,7 @@ pub struct DisplayOrderedMap<'a, K> {
 }
 
 impl<'a, K: FmtConst + 'a> fmt::Display for DisplayOrderedMap<'a, K> {
+    #[cfg(not(feature = "ptrhash"))]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
@@ -451,6 +532,82 @@ impl<'a, K: FmtConst + 'a> fmt::Display for DisplayOrderedMap<'a, K> {
                 value
             )?;
         }
+        write!(
+            f,
+            "
+    ],
+}}"
+        )
+    }
+
+    #[cfg(feature = "ptrhash")]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}::OrderedMap {{
+    key: {:?},
+    pilots: &[",
+            self.path, self.state.seed
+        )?;
+
+        for &pilot in &self.state.pilots {
+            write!(
+                f,
+                "
+        {},",
+                pilot
+            )?;
+        }
+
+        write!(
+            f,
+            "
+    ],
+    remap: &[",
+        )?;
+
+        for &index in &self.state.remap {
+            write!(
+                f,
+                "
+        {},",
+                index
+            )?;
+        }
+
+        write!(
+            f,
+            "
+    ],
+    idxs: &[",
+        )?;
+
+        for &idx in &self.state.map {
+            write!(
+                f,
+                "
+        {},",
+                idx
+            )?;
+        }
+
+        write!(
+            f,
+            "
+    ],
+    entries: &[",
+        )?;
+
+        for (key, value) in self.keys.iter().zip(self.values.iter()) {
+            write!(
+                f,
+                "
+        ({}, {}),",
+                Delegate(key),
+                value
+            )?;
+        }
+
         write!(
             f,
             "

--- a/phf_codegen/test/Cargo.toml
+++ b/phf_codegen/test/Cargo.toml
@@ -6,6 +6,9 @@ build = "build.rs"
 edition = "2021"
 publish = false
 
+[features]
+ptrhash = ["phf/ptrhash", "phf_codegen/ptrhash"]
+
 [dependencies]
 phf = { version = "^0.13.1", features = ["uncased", "unicase"] }
 uncased = { version = "0.9.7", default-features = false }

--- a/phf_generator/Cargo.toml
+++ b/phf_generator/Cargo.toml
@@ -10,6 +10,9 @@ rust-version = "1.71"
 categories = ["data-structures"]
 readme = "README.md"
 
+[features]
+ptrhash = ["phf_shared/ptrhash"]
+
 [dependencies]
 fastrand = { version = "2.1.0", default-features = false }
 phf_shared = { version = "^0.13.1", default-features = false }

--- a/phf_generator/benches/benches.rs
+++ b/phf_generator/benches/benches.rs
@@ -1,50 +1,217 @@
+use std::hint::black_box;
 use std::iter;
 
 use criterion::measurement::Measurement;
+#[cfg(feature = "ptrhash")]
+use criterion::Throughput;
 use criterion::{criterion_group, criterion_main, Bencher, BenchmarkId, Criterion};
 
 use fastrand::Rng;
 
 use phf_generator::generate_hash;
+#[cfg(feature = "ptrhash")]
+use phf_generator::{ptrhash, HashState};
 
-fn gen_vec(len: usize) -> Vec<u64> {
+fn gen_numbers(len: usize) -> Vec<u64> {
     let mut rng = Rng::with_seed(0xAAAAAAAAAAAAAAAA);
     iter::repeat_with(|| rng.u64(..)).take(len).collect()
 }
 
-fn bench_hash<M: Measurement>(b: &mut Bencher<M>, len: &usize) {
-    let vec = gen_vec(*len);
-    b.iter(|| generate_hash(&vec))
+#[cfg(feature = "ptrhash")]
+fn gen_strings(len: usize) -> Vec<String> {
+    let mut rng = Rng::with_seed(0x5555555555555555);
+    let mut chars = iter::repeat_with(|| rng.alphanumeric());
+
+    (0..len)
+        .map(move |_| chars.by_ref().take(32).collect::<String>())
+        .collect()
+}
+
+fn bench_default_hash<M: Measurement>(b: &mut Bencher<M>, len: &usize) {
+    let numbers = gen_numbers(*len);
+    b.iter(|| black_box(generate_hash(black_box(&numbers))))
+}
+
+#[cfg(feature = "ptrhash")]
+fn bench_ptrhash<M: Measurement>(b: &mut Bencher<M>, keys: &&[&str]) {
+    b.iter(|| black_box(ptrhash::generate_hash(black_box(keys))))
+}
+
+#[cfg(feature = "ptrhash")]
+fn bench_default<M: Measurement>(b: &mut Bencher<M>, keys: &&[&str]) {
+    b.iter(|| black_box(generate_hash(black_box(keys))))
+}
+
+#[cfg(feature = "ptrhash")]
+struct LookupBench {
+    keys: Vec<String>,
+    default: HashState,
+    ptrhash: ptrhash::HashState,
+    hits: Vec<String>,
+    misses: Vec<String>,
+}
+
+#[cfg(feature = "ptrhash")]
+fn build_lookup_bench(len: usize) -> LookupBench {
+    let keys = gen_strings(len);
+    let key_refs: Vec<_> = keys.iter().map(String::as_str).collect();
+    let default = generate_hash(&key_refs);
+    let ptrhash = ptrhash::generate_hash(&key_refs);
+    let hits = (0..64)
+        .map(|idx| keys[idx % len].clone())
+        .collect::<Vec<_>>();
+    let misses = (0..64)
+        .map(|idx| format!("missing:{len}:{idx}"))
+        .collect::<Vec<_>>();
+
+    LookupBench {
+        keys,
+        default,
+        ptrhash,
+        hits,
+        misses,
+    }
+}
+
+#[cfg(feature = "ptrhash")]
+fn default_lookup(data: &LookupBench, key: &str) -> bool {
+    let hashes = phf_shared::hash(key, &data.default.key);
+    let slot = phf_shared::get_index(&hashes, &data.default.disps, data.default.map.len()) as usize;
+    data.keys[data.default.map[slot]] == key
+}
+
+#[cfg(feature = "ptrhash")]
+fn ptrhash_lookup(data: &LookupBench, key: &str) -> bool {
+    let hash = phf_shared::ptrhash::hash(key, &data.ptrhash.seed);
+    let slot = phf_shared::ptrhash::get_index(
+        data.ptrhash.seed,
+        hash,
+        &data.ptrhash.pilots,
+        &data.ptrhash.remap,
+        data.ptrhash.map.len(),
+    ) as usize;
+    data.keys[data.ptrhash.map[slot]] == key
+}
+
+#[cfg(feature = "ptrhash")]
+fn bench_lookup_queries<M: Measurement>(
+    b: &mut Bencher<M>,
+    data: &LookupBench,
+    queries: &[String],
+    lookup: fn(&LookupBench, &str) -> bool,
+) {
+    b.iter(|| {
+        let mut found = 0usize;
+        for query in queries {
+            found += usize::from(lookup(data, black_box(query.as_str())));
+        }
+        black_box(found)
+    })
 }
 
 fn gen_hash_small(c: &mut Criterion) {
     let sizes = vec![0, 1, 2, 5, 10, 25, 50, 75];
     for size in &sizes {
-        c.bench_with_input(BenchmarkId::new("gen_hash_small", *size), size, bench_hash);
+        c.bench_with_input(
+            BenchmarkId::new("gen_hash_small", *size),
+            size,
+            bench_default_hash,
+        );
     }
 }
 
 fn gen_hash_med(c: &mut Criterion) {
     let sizes = vec![100, 250, 500, 1000, 2500, 5000, 7500];
     for size in &sizes {
-        c.bench_with_input(BenchmarkId::new("gen_hash_medium", *size), size, bench_hash);
+        c.bench_with_input(
+            BenchmarkId::new("gen_hash_medium", *size),
+            size,
+            bench_default_hash,
+        );
     }
 }
 
 fn gen_hash_large(c: &mut Criterion) {
     let sizes = vec![10_000, 25_000, 50_000, 75_000];
     for size in &sizes {
-        c.bench_with_input(BenchmarkId::new("gen_hash_large", *size), size, bench_hash);
+        c.bench_with_input(
+            BenchmarkId::new("gen_hash_large", *size),
+            size,
+            bench_default_hash,
+        );
     }
 }
 
 fn gen_hash_xlarge(c: &mut Criterion) {
     let sizes = vec![100_000, 250_000, 500_000, 750_000, 1_000_000];
     for size in &sizes {
-        c.bench_with_input(BenchmarkId::new("gen_hash_xlarge", *size), size, bench_hash);
+        c.bench_with_input(
+            BenchmarkId::new("gen_hash_xlarge", *size),
+            size,
+            bench_default_hash,
+        );
     }
 }
 
+#[cfg(feature = "ptrhash")]
+fn gen_hash_compare(c: &mut Criterion) {
+    for size in [0, 1, 10, 100, 1_000, 10_000] {
+        let keys = gen_strings(size);
+        let key_refs = keys.iter().map(String::as_str).collect::<Vec<_>>();
+        let key_slice = key_refs.as_slice();
+        let mut group = c.benchmark_group(format!("gen_hash_compare/{size}"));
+
+        group.bench_with_input(BenchmarkId::new("default", size), &key_slice, bench_default);
+        group.bench_with_input(BenchmarkId::new("ptrhash", size), &key_slice, bench_ptrhash);
+        group.finish();
+    }
+}
+
+#[cfg(feature = "ptrhash")]
+fn lookup_hits(c: &mut Criterion) {
+    for size in [1, 10, 100, 1_000, 10_000] {
+        let data = build_lookup_bench(size);
+        let mut group = c.benchmark_group(format!("lookup_hits/{size}"));
+        group.throughput(Throughput::Elements(data.hits.len() as u64));
+        group.bench_function("default", |b| {
+            bench_lookup_queries(b, &data, &data.hits, default_lookup)
+        });
+        group.bench_function("ptrhash", |b| {
+            bench_lookup_queries(b, &data, &data.hits, ptrhash_lookup)
+        });
+        group.finish();
+    }
+}
+
+#[cfg(feature = "ptrhash")]
+fn lookup_misses(c: &mut Criterion) {
+    for size in [1, 10, 100, 1_000, 10_000] {
+        let data = build_lookup_bench(size);
+        let mut group = c.benchmark_group(format!("lookup_misses/{size}"));
+        group.throughput(Throughput::Elements(data.misses.len() as u64));
+        group.bench_function("default", |b| {
+            bench_lookup_queries(b, &data, &data.misses, default_lookup)
+        });
+        group.bench_function("ptrhash", |b| {
+            bench_lookup_queries(b, &data, &data.misses, ptrhash_lookup)
+        });
+        group.finish();
+    }
+}
+
+#[cfg(feature = "ptrhash")]
+criterion_group!(
+    benches,
+    gen_hash_small,
+    gen_hash_med,
+    gen_hash_large,
+    gen_hash_xlarge,
+    gen_hash_compare,
+    lookup_hits,
+    lookup_misses
+);
+
+#[cfg(not(feature = "ptrhash"))]
 criterion_group!(
     benches,
     gen_hash_small,

--- a/phf_generator/src/lib.rs
+++ b/phf_generator/src/lib.rs
@@ -12,6 +12,9 @@ const DEFAULT_LAMBDA: usize = 5;
 
 const FIXED_SEED: u64 = 1234567890;
 
+#[cfg(feature = "ptrhash")]
+pub mod ptrhash;
+
 pub struct HashState {
     pub key: HashKey,
     pub disps: Vec<(u32, u32)>,

--- a/phf_generator/src/ptrhash.rs
+++ b/phf_generator/src/ptrhash.rs
@@ -1,0 +1,261 @@
+use core::cmp;
+
+use fastrand::Rng;
+use phf_shared::ptrhash::{fast_reduct32, hash as ptrhash_hash, hash_pilot};
+use phf_shared::{HashKey, PhfHash};
+
+use crate::FIXED_SEED;
+
+const DEFAULT_ALPHA: f64 = 0.99;
+const DEFAULT_LAMBDA: f64 = 3.0;
+
+pub struct HashState {
+    pub seed: u64,
+    pub pilots: Vec<u8>,
+    pub remap: Vec<u32>,
+    pub map: Vec<usize>,
+}
+
+pub fn generate_hash<H: PhfHash>(entries: &[H]) -> HashState {
+    generate_hash_with_hash_fn(entries, ptrhash_hash)
+}
+
+pub fn generate_hash_with_hash_fn<T, F>(entries: &[T], hash_fn: F) -> HashState
+where
+    F: Fn(&T, &HashKey) -> u64,
+{
+    if entries.is_empty() {
+        return HashState {
+            seed: 0,
+            pilots: vec![],
+            remap: vec![],
+            map: vec![],
+        };
+    }
+
+    let mut rng = Rng::with_seed(FIXED_SEED);
+    let mut hashes = vec![0; entries.len()];
+
+    loop {
+        let seed = rng.u64(..);
+        for (hash, entry) in hashes.iter_mut().zip(entries) {
+            *hash = hash_fn(entry, &seed);
+        }
+
+        if let Some(state) = try_generate_hash(seed, &hashes) {
+            return state;
+        }
+    }
+}
+
+#[derive(Default)]
+struct Bucket {
+    keys: Vec<usize>,
+}
+
+#[derive(Clone, Copy)]
+struct Slot {
+    bucket: usize,
+    key: usize,
+}
+
+fn try_generate_hash(seed: u64, hashes: &[u64]) -> Option<HashState> {
+    let table_len = hashes.len();
+    let table_len_u32 = table_len.try_into().unwrap();
+    let slots_len = adjusted_slots_len(table_len_u32) as usize;
+    let buckets_len = adjusted_buckets_len(table_len_u32) as usize;
+
+    let mut buckets = (0..buckets_len)
+        .map(|_| Bucket::default())
+        .collect::<Vec<_>>();
+    let mut pilots = vec![0; buckets_len];
+    let mut order = (0..buckets_len).collect::<Vec<_>>();
+    let mut slots = vec![None; slots_len];
+    let mut stack = Vec::new();
+    let mut recent = Vec::new();
+    let mut values_to_add = Vec::with_capacity((DEFAULT_LAMBDA as usize) * 2);
+    let mut already_scored = Vec::new();
+
+    for (idx, &hash) in hashes.iter().enumerate() {
+        let bucket = fast_reduct32(low(hash), buckets_len as u32) as usize;
+        buckets[bucket].keys.push(idx);
+    }
+
+    order.sort_unstable_by_key(|&bucket| cmp::Reverse(buckets[bucket].keys.len()));
+
+    for &bucket in &order {
+        if buckets[bucket].keys.is_empty() {
+            continue;
+        }
+
+        recent.clear();
+        stack.clear();
+        stack.push(bucket);
+
+        'bucket: while let Some(bucket) = {
+            stack.sort_unstable_by_key(|&bucket| buckets[bucket].keys.len());
+            stack.pop()
+        } {
+            recent.push(bucket);
+
+            for pilot in 0..=u8::MAX {
+                if try_place_bucket(
+                    &buckets,
+                    &mut slots,
+                    &mut pilots,
+                    &mut values_to_add,
+                    hashes,
+                    seed,
+                    bucket,
+                    pilot,
+                ) {
+                    continue 'bucket;
+                }
+            }
+
+            let mut best = None;
+
+            'pilot: for offset in 0..=u8::MAX {
+                let pilot = offset.wrapping_add(0x42);
+                let pilot_hash = hash_pilot(seed, pilot);
+                let mut score = 0;
+
+                values_to_add.clear();
+                already_scored.clear();
+
+                for &key in &buckets[bucket].keys {
+                    let slot = slot_index(hashes[key], pilot_hash, slots.len() as u32);
+                    if values_to_add.iter().any(|&(seen, _)| seen == slot) {
+                        continue 'pilot;
+                    }
+
+                    let extra = match slots[slot as usize] {
+                        None => 0,
+                        Some(slot) if recent.contains(&slot.bucket) => continue 'pilot,
+                        Some(slot) if !already_scored.contains(&slot.bucket) => {
+                            already_scored.push(slot.bucket);
+                            buckets[slot.bucket].keys.len().pow(2)
+                        }
+                        Some(_) => 0,
+                    };
+
+                    values_to_add.push((slot, key));
+                    score += extra;
+
+                    if best
+                        .map(|(best_score, _)| score >= best_score)
+                        .unwrap_or(false)
+                    {
+                        continue 'pilot;
+                    }
+                }
+
+                best = Some((score, pilot));
+                if score == buckets[bucket].keys.len().pow(2) {
+                    break;
+                }
+            }
+
+            let (_, pilot) = best?;
+            pilots[bucket] = pilot;
+            let pilot_hash = hash_pilot(seed, pilot);
+
+            for &key in &buckets[bucket].keys {
+                let slot = slot_index(hashes[key], pilot_hash, slots.len() as u32) as usize;
+                if let Some(previous) = slots[slot].replace(Slot { bucket, key }) {
+                    stack.push(previous.bucket);
+
+                    let previous_hash = hash_pilot(seed, pilots[previous.bucket]);
+                    let slots_len = slots.len() as u32;
+                    for previous_slot in buckets[previous.bucket]
+                        .keys
+                        .iter()
+                        .map(|&key| slot_index(hashes[key], previous_hash, slots_len) as usize)
+                        .filter(|&previous_slot| previous_slot != slot)
+                    {
+                        slots[previous_slot] = None;
+                    }
+                }
+            }
+        }
+    }
+
+    let mut map = vec![0; table_len];
+    let mut remap = vec![0; slots.len() - table_len];
+    let mut free_slots = Vec::new();
+
+    for (slot, entry) in slots.iter().enumerate() {
+        match (slot < table_len, entry) {
+            (true, Some(entry)) => map[slot] = entry.key,
+            (true, None) => free_slots.push(slot),
+            (false, Some(entry)) => {
+                let remapped = free_slots.pop().unwrap();
+                remap[slot - table_len] = remapped.try_into().unwrap();
+                map[remapped] = entry.key;
+            }
+            (false, None) => {}
+        }
+    }
+
+    Some(HashState {
+        seed,
+        pilots,
+        remap,
+        map,
+    })
+}
+
+fn adjusted_slots_len(keys_len: u32) -> u32 {
+    let len = (f64::from(keys_len) / DEFAULT_ALPHA).ceil() as u32;
+    len + u32::from(len.is_power_of_two())
+}
+
+fn adjusted_buckets_len(keys_len: u32) -> u32 {
+    let len = (f64::from(keys_len) / DEFAULT_LAMBDA).ceil() as u32;
+    len + 3
+}
+
+fn try_place_bucket(
+    buckets: &[Bucket],
+    slots: &mut [Option<Slot>],
+    pilots: &mut [u8],
+    values_to_add: &mut Vec<(u32, usize)>,
+    hashes: &[u64],
+    seed: u64,
+    bucket: usize,
+    pilot: u8,
+) -> bool {
+    let pilot_hash = hash_pilot(seed, pilot);
+    values_to_add.clear();
+
+    for &key in &buckets[bucket].keys {
+        let slot = slot_index(hashes[key], pilot_hash, slots.len() as u32);
+        if slots[slot as usize].is_some() || values_to_add.iter().any(|&(seen, _)| seen == slot) {
+            return false;
+        }
+
+        values_to_add.push((slot, key));
+    }
+
+    pilots[bucket] = pilot;
+    for &(slot, key) in values_to_add.iter() {
+        slots[slot as usize] = Some(Slot { bucket, key });
+    }
+
+    true
+}
+
+#[inline]
+fn slot_index(hash: u64, pilot_hash: u64, slots_len: u32) -> u32 {
+    fast_reduct32(high(hash) ^ high(pilot_hash) ^ low(pilot_hash), slots_len)
+}
+
+#[inline]
+fn low(v: u64) -> u32 {
+    v as u32
+}
+
+#[inline]
+fn high(v: u64) -> u32 {
+    (v >> 32) as u32
+}

--- a/phf_macros/Cargo.toml
+++ b/phf_macros/Cargo.toml
@@ -16,6 +16,7 @@ proc-macro = true
 [features]
 unicase = ["unicase_", "phf_shared/unicase"]
 uncased = ["uncased_", "phf_shared/uncased"]
+ptrhash = ["phf_generator/ptrhash"]
 
 [dependencies]
 syn = { version = "2", features = ["full"] }

--- a/phf_macros/src/lib.rs
+++ b/phf_macros/src/lib.rs
@@ -3,6 +3,9 @@
 //!
 //! [phf]: https://docs.rs/phf
 
+#[cfg(feature = "ptrhash")]
+use phf_generator::ptrhash::HashState;
+#[cfg(not(feature = "ptrhash"))]
 use phf_generator::HashState;
 use phf_shared::PhfHash;
 use proc_macro::TokenStream;
@@ -232,6 +235,18 @@ impl ParsedKey {
     }
 }
 
+fn generate_hash_state<H: PhfHash>(entries: &[H]) -> HashState {
+    #[cfg(not(feature = "ptrhash"))]
+    {
+        phf_generator::generate_hash(entries)
+    }
+
+    #[cfg(feature = "ptrhash")]
+    {
+        phf_generator::ptrhash::generate_hash(entries)
+    }
+}
+
 #[derive(Clone)]
 struct Key {
     parsed: Vec<ParsedKey>,
@@ -422,42 +437,91 @@ fn check_duplicates(entries: &[Entry]) -> parse::Result<()> {
 }
 
 fn build_map(entries: &[Entry], state: HashState) -> proc_macro2::TokenStream {
-    let key = state.key;
-    let disps = state.disps.iter().map(|&(d1, d2)| quote!((#d1, #d2)));
-    let entries = state.map.iter().map(|&idx| {
-        let entry = &entries[idx];
-        let key = &entry.key.expr[0]; // Use the first expression
-        let value = &entry.value;
-        // Don't include attributes since we've filtered at macro expansion time
-        quote!((#key, #value))
-    });
+    #[cfg(not(feature = "ptrhash"))]
+    {
+        let key = state.key;
+        let disps = state.disps.iter().map(|&(d1, d2)| quote!((#d1, #d2)));
+        let entries = state.map.iter().map(|&idx| {
+            let entry = &entries[idx];
+            let key = &entry.key.expr[0];
+            let value = &entry.value;
+            quote!((#key, #value))
+        });
 
-    quote! {
-        phf::Map {
-            key: #key,
-            disps: &[#(#disps),*],
-            entries: &[#(#entries),*],
+        quote! {
+            phf::Map {
+                key: #key,
+                disps: &[#(#disps),*],
+                entries: &[#(#entries),*],
+            }
+        }
+    }
+
+    #[cfg(feature = "ptrhash")]
+    {
+        let key = state.seed;
+        let pilots = state.pilots.iter().map(|pilot| quote!(#pilot));
+        let remap = state.remap.iter().map(|index| quote!(#index));
+        let entries = state.map.iter().map(|&idx| {
+            let entry = &entries[idx];
+            let key = &entry.key.expr[0];
+            let value = &entry.value;
+            quote!((#key, #value))
+        });
+
+        quote! {
+            phf::Map {
+                key: #key,
+                pilots: &[#(#pilots),*],
+                remap: &[#(#remap),*],
+                entries: &[#(#entries),*],
+            }
         }
     }
 }
 
 fn build_ordered_map(entries: &[Entry], state: HashState) -> proc_macro2::TokenStream {
-    let key = state.key;
-    let disps = state.disps.iter().map(|&(d1, d2)| quote!((#d1, #d2)));
-    let idxs = state.map.iter().map(|idx| quote!(#idx));
-    let entries = entries.iter().map(|entry| {
-        let key = &entry.key.expr[0]; // Use the first expression
-        let value = &entry.value;
-        // Don't include attributes since we've filtered at macro expansion time
-        quote!((#key, #value))
-    });
+    #[cfg(not(feature = "ptrhash"))]
+    {
+        let key = state.key;
+        let disps = state.disps.iter().map(|&(d1, d2)| quote!((#d1, #d2)));
+        let idxs = state.map.iter().map(|idx| quote!(#idx));
+        let entries = entries.iter().map(|entry| {
+            let key = &entry.key.expr[0];
+            let value = &entry.value;
+            quote!((#key, #value))
+        });
 
-    quote! {
-        phf::OrderedMap {
-            key: #key,
-            disps: &[#(#disps),*],
-            idxs: &[#(#idxs),*],
-            entries: &[#(#entries),*],
+        quote! {
+            phf::OrderedMap {
+                key: #key,
+                disps: &[#(#disps),*],
+                idxs: &[#(#idxs),*],
+                entries: &[#(#entries),*],
+            }
+        }
+    }
+
+    #[cfg(feature = "ptrhash")]
+    {
+        let key = state.seed;
+        let pilots = state.pilots.iter().map(|pilot| quote!(#pilot));
+        let remap = state.remap.iter().map(|index| quote!(#index));
+        let idxs = state.map.iter().map(|idx| quote!(#idx));
+        let entries = entries.iter().map(|entry| {
+            let key = &entry.key.expr[0];
+            let value = &entry.value;
+            quote!((#key, #value))
+        });
+
+        quote! {
+            phf::OrderedMap {
+                key: #key,
+                pilots: &[#(#pilots),*],
+                remap: &[#(#remap),*],
+                idxs: &[#(#idxs),*],
+                entries: &[#(#entries),*],
+            }
         }
     }
 }
@@ -471,7 +535,7 @@ pub fn phf_map(input: TokenStream) -> TokenStream {
 
     if !has_cfg_attrs {
         // No cfg attributes - use the simple approach
-        let state = phf_generator::generate_hash(&map.0);
+        let state = generate_hash_state(&map.0);
         build_map(&map.0, state).into()
     } else {
         // Has cfg attributes - need to generate conditional map code
@@ -547,7 +611,7 @@ where
     let conditional: Vec<_> = entries.iter().filter(|e| !e.attrs.is_empty()).collect();
 
     if conditional.is_empty() {
-        let state = phf_generator::generate_hash(entries);
+        let state = generate_hash_state(entries);
         return simple_builder(entries, state);
     }
 
@@ -568,7 +632,7 @@ where
         }
 
         let entries_vec: Vec<Entry> = variant_entries.into_iter().cloned().collect();
-        let state = phf_generator::generate_hash(&entries_vec);
+        let state = generate_hash_state(&entries_vec);
         let structure_tokens = simple_builder(&entries_vec, state);
 
         let conditions = build_cfg_conditions(mask, &conditional);
@@ -585,17 +649,32 @@ where
 }
 
 fn build_conditional_phf_map(entries: &[Entry]) -> proc_macro2::TokenStream {
-    build_conditional_phf(
-        entries,
-        build_map,
+    build_conditional_phf(entries, build_map, empty_map())
+}
+
+fn empty_map() -> proc_macro2::TokenStream {
+    #[cfg(not(feature = "ptrhash"))]
+    {
         quote! {
             phf::Map {
                 key: 0,
                 disps: &[],
                 entries: &[],
             }
-        },
-    )
+        }
+    }
+
+    #[cfg(feature = "ptrhash")]
+    {
+        quote! {
+            phf::Map {
+                key: 0,
+                pilots: &[],
+                remap: &[],
+                entries: &[],
+            }
+        }
+    }
 }
 
 #[proc_macro]
@@ -607,7 +686,7 @@ pub fn phf_set(input: TokenStream) -> TokenStream {
 
     if !has_cfg_attrs {
         // No cfg attributes - use the simple approach
-        let state = phf_generator::generate_hash(&set.0);
+        let state = generate_hash_state(&set.0);
         let map = build_map(&set.0, state);
         quote!(phf::Set { map: #map }).into()
     } else {
@@ -631,7 +710,7 @@ pub fn phf_ordered_map(input: TokenStream) -> TokenStream {
 
     if !has_cfg_attrs {
         // No cfg attributes - use the simple approach
-        let state = phf_generator::generate_hash(&map.0);
+        let state = generate_hash_state(&map.0);
         build_ordered_map(&map.0, state).into()
     } else {
         // Has cfg attributes - need to generate conditional ordered map code
@@ -640,9 +719,12 @@ pub fn phf_ordered_map(input: TokenStream) -> TokenStream {
 }
 
 fn build_conditional_phf_ordered_map(entries: &[Entry]) -> proc_macro2::TokenStream {
-    build_conditional_phf(
-        entries,
-        build_ordered_map,
+    build_conditional_phf(entries, build_ordered_map, empty_ordered_map())
+}
+
+fn empty_ordered_map() -> proc_macro2::TokenStream {
+    #[cfg(not(feature = "ptrhash"))]
+    {
         quote! {
             phf::OrderedMap {
                 key: 0,
@@ -650,8 +732,21 @@ fn build_conditional_phf_ordered_map(entries: &[Entry]) -> proc_macro2::TokenStr
                 idxs: &[],
                 entries: &[],
             }
-        },
-    )
+        }
+    }
+
+    #[cfg(feature = "ptrhash")]
+    {
+        quote! {
+            phf::OrderedMap {
+                key: 0,
+                pilots: &[],
+                remap: &[],
+                idxs: &[],
+                entries: &[],
+            }
+        }
+    }
 }
 
 #[proc_macro]
@@ -662,7 +757,7 @@ pub fn phf_ordered_set(input: TokenStream) -> TokenStream {
 
     if !has_cfg_attrs {
         // No cfg attributes - use the simple approach
-        let state = phf_generator::generate_hash(&set.0);
+        let state = generate_hash_state(&set.0);
         let map = build_ordered_map(&set.0, state);
         quote!(phf::OrderedSet { map: #map }).into()
     } else {

--- a/phf_macros_test/Cargo.toml
+++ b/phf_macros_test/Cargo.toml
@@ -23,3 +23,4 @@ uncased = "0.9.7"
 default = ["enabled_feature"]
 disabled_feature = []
 enabled_feature = []
+ptrhash = ["phf/ptrhash", "phf_macros/ptrhash"]

--- a/phf_shared/Cargo.toml
+++ b/phf_shared/Cargo.toml
@@ -18,6 +18,7 @@ test = false
 [features]
 default = ["std"]
 std = []
+ptrhash = []
 
 [dependencies]
 siphasher = "1.0"

--- a/phf_shared/src/lib.rs
+++ b/phf_shared/src/lib.rs
@@ -13,6 +13,9 @@ use core::hash::{Hash, Hasher};
 use core::num::Wrapping;
 use siphasher::sip128::{Hash128, Hasher128, SipHasher13};
 
+#[cfg(feature = "ptrhash")]
+pub mod ptrhash;
+
 #[non_exhaustive]
 pub struct Hashes {
     pub g: u32,

--- a/phf_shared/src/ptrhash.rs
+++ b/phf_shared/src/ptrhash.rs
@@ -1,0 +1,59 @@
+use core::hash::Hasher;
+use siphasher::sip::SipHasher13;
+
+use crate::{HashKey, PhfHash};
+
+/// `key` is from `phf_generator::ptrhash::HashState`.
+#[inline]
+pub fn hash<T: ?Sized + PhfHash>(x: &T, key: &HashKey) -> u64 {
+    let mut hasher = SipHasher13::new_with_keys(0, *key);
+    x.phf_hash(&mut hasher);
+    hasher.finish()
+}
+
+#[inline]
+pub fn hash_pilot(seed: u64, pilot: u8) -> u64 {
+    const C: u64 = 0x517cc1b727220a95;
+
+    C.wrapping_mul(seed ^ u64::from(pilot))
+}
+
+/// Return an index into `phf_generator::ptrhash::HashState::map`.
+///
+/// * `seed` is from `phf_generator::ptrhash::HashState::seed`.
+/// * `hash` is from `hash()` in this crate.
+/// * `pilots` is from `phf_generator::ptrhash::HashState::pilots`.
+/// * `remap` is from `phf_generator::ptrhash::HashState::remap`.
+/// * `len` is the length of `phf_generator::ptrhash::HashState::map`.
+#[inline]
+pub fn get_index(seed: u64, hash: u64, pilots: &[u8], remap: &[u32], len: usize) -> u32 {
+    let pilots_len = pilots.len() as u32;
+    let slots_len = (len + remap.len()) as u32;
+
+    let bucket = fast_reduct32(low(hash), pilots_len) as usize;
+    let pilot_hash = hash_pilot(seed, pilots[bucket]);
+    let index = fast_reduct32(high(hash) ^ high(pilot_hash) ^ low(pilot_hash), slots_len);
+    let index = index as usize;
+
+    if index < len {
+        index as u32
+    } else {
+        remap[index - len]
+    }
+}
+
+// https://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/
+#[inline]
+pub fn fast_reduct32(x: u32, limit: u32) -> u32 {
+    (((x as u64) * (limit as u64)) >> 32) as u32
+}
+
+#[inline]
+fn low(v: u64) -> u32 {
+    v as u32
+}
+
+#[inline]
+fn high(v: u64) -> u32 {
+    (v >> 32) as u32
+}


### PR DESCRIPTION
slightly modified version of #357, opened as another PR not to mess up the original.

Close #349

## Benchmark results

### Generation

| keys | default CHD | ptrhash | result |
| --- | ---: | ---: | --- |
| 0 | 11.57 ns | 5.73 ns | ptrhash 2.0x faster |
| 1 | 120.35 ns | 134.31 ns | ptrhash 11.6% slower |
| 10 | 3.239 us | 0.340 us | ptrhash 9.5x faster |
| 100 | 115.98 us | 5.191 us | ptrhash 22.3x faster |
| 1,000 | 400.20 us | 46.63 us | ptrhash 8.6x faster |
| 10,000 | 6.163 ms | 0.750 ms | ptrhash 8.2x faster |

### Lookup Hits

| keys | default CHD | ptrhash | throughput delta |
| --- | ---: | ---: | --- |
| 1 | 917.57 ns | 712.46 ns | ptrhash +28.8% |
| 1,000 | 896.43 ns | 708.70 ns | ptrhash +26.5% |
| 10,000 | 910.20 ns | 707.22 ns | ptrhash +28.7% |

### Lookup Misses

| keys | default CHD | ptrhash | throughput delta |
| --- | ---: | ---: | --- |
| 1 | 615.65 ns | 457.73 ns | ptrhash +34.5% |
| 10 | 610.47 ns | 451.75 ns | ptrhash +35.1% |
| 100 | 607.60 ns | 464.73 ns | ptrhash +30.7% |
| 1,000 | 610.63 ns | 461.38 ns | ptrhash +32.3% |
| 10,000 | 657.13 ns | 501.28 ns | ptrhash +31.1% |