### PR TITLE
feat: add `FmtConst` support for `Vec`/slice keys

### DIFF
--- a/phf_codegen/test/build.rs
+++ b/phf_codegen/test/build.rs
@@ -123,6 +123,56 @@ fn main() -> io::Result<()> {
             .build()
     )?;
 
+    writeln!(
+        &mut file,
+        "static BYTE_VEC_KEYS: ::phf::Map<&'static [u8], u32> = \n{};",
+        phf_codegen::Map::<Vec<u8>>::new()
+            .entry(b"foo".to_vec(), "0")
+            .entry(b"bar".to_vec(), "1")
+            .entry(b"baz".to_vec(), "2")
+            .build()
+    )?;
+
+    writeln!(
+        &mut file,
+        "static U32_VEC_KEYS: ::phf::Map<&'static [u32], &'static str> = \n{};",
+        phf_codegen::Map::<Vec<u32>>::new()
+            .entry(vec![1u32, 2, 3], "\"a\"")
+            .entry(vec![4u32, 5, 6], "\"b\"")
+            .entry(vec![7u32, 8, 9], "\"c\"")
+            .build()
+    )?;
+
+    writeln!(
+        &mut file,
+        "static U32_VEC_SET: ::phf::Set<&'static [u32]> = \n{};",
+        phf_codegen::Set::<Vec<u32>>::new()
+            .entry(vec![1u32, 2, 3])
+            .entry(vec![4u32, 5, 6])
+            .entry(vec![7u32, 8, 9])
+            .build()
+    )?;
+
+    writeln!(
+        &mut file,
+        "static U32_VEC_ORDERED_MAP: ::phf::OrderedMap<&'static [u32], &'static str> = \n{};",
+        phf_codegen::OrderedMap::<Vec<u32>>::new()
+            .entry(vec![1u32, 2, 3], "\"a\"")
+            .entry(vec![4u32, 5, 6], "\"b\"")
+            .entry(vec![7u32, 8, 9], "\"c\"")
+            .build()
+    )?;
+
+    writeln!(
+        &mut file,
+        "static U32_VEC_ORDERED_SET: ::phf::OrderedSet<&'static [u32]> = \n{};",
+        phf_codegen::OrderedSet::<Vec<u32>>::new()
+            .entry(vec![1u32, 2, 3])
+            .entry(vec![4u32, 5, 6])
+            .entry(vec![7u32, 8, 9])
+            .build()
+    )?;
+
     // Test FromIterator implementation
     writeln!(
         &mut file,

--- a/phf_codegen/test/src/lib.rs
+++ b/phf_codegen/test/src/lib.rs
@@ -109,6 +109,51 @@ mod test {
     }
 
     #[test]
+    fn byte_vec_keys() {
+        assert_eq!(0, BYTE_VEC_KEYS[&b"foo"[..]]);
+        assert_eq!(1, BYTE_VEC_KEYS[&b"bar"[..]]);
+        assert_eq!(2, BYTE_VEC_KEYS[&b"baz"[..]]);
+    }
+
+    #[test]
+    fn u32_vec_keys() {
+        assert_eq!("a", U32_VEC_KEYS[&[1u32, 2, 3][..]]);
+        assert_eq!("b", U32_VEC_KEYS[&[4u32, 5, 6][..]]);
+        assert_eq!("c", U32_VEC_KEYS[&[7u32, 8, 9][..]]);
+        assert!(!U32_VEC_KEYS.contains_key(&[10u32, 11, 12][..]));
+    }
+
+    #[test]
+    fn u32_vec_set() {
+        assert!(U32_VEC_SET.contains(&[1u32, 2, 3][..]));
+        assert!(U32_VEC_SET.contains(&[4u32, 5, 6][..]));
+        assert!(U32_VEC_SET.contains(&[7u32, 8, 9][..]));
+        assert!(!U32_VEC_SET.contains(&[10u32, 11, 12][..]));
+    }
+
+    #[test]
+    fn u32_vec_ordered_map() {
+        assert_eq!("a", U32_VEC_ORDERED_MAP[&[1u32, 2, 3][..]]);
+        assert_eq!("b", U32_VEC_ORDERED_MAP[&[4u32, 5, 6][..]]);
+        assert_eq!("c", U32_VEC_ORDERED_MAP[&[7u32, 8, 9][..]]);
+        assert_eq!(
+            &[&[1u32, 2, 3][..], &[4u32, 5, 6][..], &[7u32, 8, 9][..]],
+            &U32_VEC_ORDERED_MAP.keys().copied().collect::<Vec<_>>()[..]
+        );
+    }
+
+    #[test]
+    fn u32_vec_ordered_set() {
+        assert!(U32_VEC_ORDERED_SET.contains(&[1u32, 2, 3][..]));
+        assert!(U32_VEC_ORDERED_SET.contains(&[4u32, 5, 6][..]));
+        assert!(U32_VEC_ORDERED_SET.contains(&[7u32, 8, 9][..]));
+        assert_eq!(
+            &[&[1u32, 2, 3][..], &[4u32, 5, 6][..], &[7u32, 8, 9][..]],
+            &U32_VEC_ORDERED_SET.iter().copied().collect::<Vec<_>>()[..]
+        );
+    }
+
+    #[test]
     fn empty_map() {
         assert_eq!(None, EMPTY.get(&1));
     }

--- a/phf_macros_test/tests/compile-fail/mixed.stderr
+++ b/phf_macros_test/tests/compile-fail/mixed.stderr
@@ -20,8 +20,8 @@ error[E0277]: the trait bound `UniCase<&str>: phf_shared::PhfBorrow<_>` is not s
    |              required by a bound introduced by this call
    |
    = help: the following other types implement trait `phf_shared::PhfBorrow<B>`:
-             `&[u8; N]` implements `phf_shared::PhfBorrow<[u8; N]>`
-             `&[u8]` implements `phf_shared::PhfBorrow<[u8]>`
+             `&[T; N]` implements `phf_shared::PhfBorrow<[T; N]>`
+             `&[T]` implements `phf_shared::PhfBorrow<[T]>`
              `&str` implements `phf_shared::PhfBorrow<str>`
              `(A, B)` implements `phf_shared::PhfBorrow<(A, B)>`
              `(A, B, C)` implements `phf_shared::PhfBorrow<(A, B, C)>`

--- a/phf_shared/src/lib.rs
+++ b/phf_shared/src/lib.rs
@@ -203,13 +203,6 @@ impl PhfBorrow<str> for String {
 }
 
 #[cfg(feature = "std")]
-impl PhfBorrow<[u8]> for Vec<u8> {
-    fn borrow(&self) -> &[u8] {
-        self
-    }
-}
-
-#[cfg(feature = "std")]
 delegate_debug!(String);
 
 #[cfg(feature = "std")]
@@ -221,10 +214,10 @@ impl PhfHash for String {
 }
 
 #[cfg(feature = "std")]
-impl PhfHash for Vec<u8> {
+impl<T: PhfHash> PhfHash for Vec<T> {
     #[inline]
     fn phf_hash<H: Hasher>(&self, state: &mut H) {
-        (**self).phf_hash(state)
+        self.as_slice().phf_hash(state)
     }
 }
 
@@ -246,14 +239,21 @@ impl PhfBorrow<str> for &str {
     }
 }
 
-impl PhfBorrow<[u8]> for &[u8] {
-    fn borrow(&self) -> &[u8] {
+#[cfg(feature = "std")]
+impl<T> PhfBorrow<[T]> for Vec<T> {
+    fn borrow(&self) -> &[T] {
         self
     }
 }
 
-impl<const N: usize> PhfBorrow<[u8; N]> for &[u8; N] {
-    fn borrow(&self) -> &[u8; N] {
+impl<T> PhfBorrow<[T]> for &[T] {
+    fn borrow(&self) -> &[T] {
+        self
+    }
+}
+
+impl<T, const N: usize> PhfBorrow<[T; N]> for &[T; N] {
+    fn borrow(&self) -> &[T; N] {
         self
     }
 }
@@ -262,14 +262,6 @@ impl PhfHash for str {
     #[inline]
     fn phf_hash<H: Hasher>(&self, state: &mut H) {
         self.as_bytes().phf_hash(state)
-    }
-}
-
-impl FmtConst for [u8] {
-    #[inline]
-    fn fmt_const(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // slices need a leading reference
-        write!(f, "&{:?}", self)
     }
 }
 
@@ -432,9 +424,31 @@ impl<T: PhfHash> PhfHash for [T] {
 }
 
 // minimize duplicated code since formatting drags in quite a bit
+fn fmt_slice<T: core::fmt::Debug>(slice: &[T], f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    // slices need a leading reference
+    write!(f, "&{:?}", slice)
+}
+
 fn fmt_array<T: core::fmt::Debug>(array: &[T], f: &mut fmt::Formatter<'_>) -> fmt::Result {
     write!(f, "{:?}", array)
 }
+
+macro_rules! slice_impl (
+    ($t:ty) => (
+        impl FmtConst for [$t] {
+            fn fmt_const(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                fmt_slice(self, f)
+            }
+        }
+
+        #[cfg(feature = "std")]
+        impl FmtConst for Vec<$t> {
+            fn fmt_const(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                self.as_slice().fmt_const(f)
+            }
+        }
+    )
+);
 
 macro_rules! array_impl (
     ($t:ty) => (
@@ -451,6 +465,21 @@ macro_rules! array_impl (
         }
     )
 );
+
+slice_impl!(u8);
+slice_impl!(i8);
+slice_impl!(u16);
+slice_impl!(i16);
+slice_impl!(u32);
+slice_impl!(i32);
+slice_impl!(u64);
+slice_impl!(i64);
+slice_impl!(usize);
+slice_impl!(isize);
+slice_impl!(u128);
+slice_impl!(i128);
+slice_impl!(bool);
+slice_impl!(char);
 
 array_impl!(u8);
 array_impl!(i8);
@@ -614,6 +643,19 @@ mod tests {
     fn slices_and_arrays_are_hashed_consistently() {
         assert_eq!(test_hash(&[1u8, 2, 3]), test_hash(&[1u8, 2, 3][..]));
         assert_eq!(test_hash(&[1u16, 2, 3]), test_hash(&[1u16, 2, 3][..]));
+    }
+
+    #[test]
+    fn array_reference_borrow_is_generic() {
+        fn assert_borrow<K, B: ?Sized>()
+        where
+            K: PhfBorrow<B>,
+        {
+        }
+
+        assert_borrow::<&[u32; 2], [u32; 2]>();
+        assert_borrow::<&[bool; 2], [bool; 2]>();
+        assert_borrow::<&[char; 2], [char; 2]>();
     }
 
     #[test]


### PR DESCRIPTION
Also simplifies some implementation.
Close #185