### PR TITLE
fix: implement `PhfEq` to address tuple lifetime issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ work as you want. See [#196] for example.
 Integer literals in the first key's type shape must use explicit suffixes, such
 as `0u32`, `[0u8, 1]`, or `(0u32, 1u32)`; later keys infer unsuffixed integer
 literals from the same position in that first key.
+Tuple keys are supported up to 12 elements.
 All keys must use the same supported key expression type as the first key.
 
 [#196]: https://github.com/rust-phf/rust-phf/issues/196

--- a/phf/src/lib.rs
+++ b/phf/src/lib.rs
@@ -94,7 +94,7 @@ extern crate std as core;
 ///   literals in the first key's type shape must have suffixes; later
 ///   unsuffixed integers infer from the same position in that first key)
 /// - arrays of `u8` integer literals
-/// - tuples of any supported key expressions
+/// - tuples of any supported key expressions, up to 12 elements
 /// - dereferenced byte string literals
 /// - OR patterns using `|` to map multiple keys to the same value
 /// - `UniCase::unicode(string)`, `UniCase::ascii(string)`, or `Ascii::new(string)` if the `unicase` feature is enabled
@@ -267,7 +267,7 @@ pub use self::ordered_map::OrderedMap;
 pub use self::ordered_set::OrderedSet;
 #[doc(inline)]
 pub use self::set::Set;
-pub use phf_shared::PhfHash;
+pub use phf_shared::{PhfEq, PhfHash};
 
 pub mod map;
 pub mod ordered_map;

--- a/phf/src/map.rs
+++ b/phf/src/map.rs
@@ -4,7 +4,7 @@ use core::iter::FusedIterator;
 use core::iter::IntoIterator;
 use core::ops::Index;
 use core::slice;
-use phf_shared::{self, HashKey, PhfBorrow, PhfHash};
+use phf_shared::{self, HashKey, PhfEq, PhfHash};
 #[cfg(feature = "serde")]
 use serde::ser::{Serialize, SerializeMap, Serializer};
 
@@ -57,7 +57,7 @@ where
 impl<'a, K, V, T: ?Sized> Index<&'a T> for Map<K, V>
 where
     T: Eq + PhfHash,
-    K: PhfBorrow<T>,
+    K: PhfEq<T>,
 {
     type Output = V;
 
@@ -134,7 +134,7 @@ impl<K, V> Map<K, V> {
     pub fn contains_key<T>(&self, key: &T) -> bool
     where
         T: Eq + PhfHash + ?Sized,
-        K: PhfBorrow<T>,
+        K: PhfEq<T>,
     {
         self.get(key).is_some()
     }
@@ -143,7 +143,7 @@ impl<K, V> Map<K, V> {
     pub fn get<T>(&self, key: &T) -> Option<&V>
     where
         T: Eq + PhfHash + ?Sized,
-        K: PhfBorrow<T>,
+        K: PhfEq<T>,
     {
         self.get_entry(key).map(|e| e.1)
     }
@@ -155,7 +155,7 @@ impl<K, V> Map<K, V> {
     pub fn get_key<T>(&self, key: &T) -> Option<&K>
     where
         T: Eq + PhfHash + ?Sized,
-        K: PhfBorrow<T>,
+        K: PhfEq<T>,
     {
         self.get_entry(key).map(|e| e.0)
     }
@@ -165,7 +165,7 @@ impl<K, V> Map<K, V> {
     pub fn get_entry<T>(&self, key: &T) -> Option<(&K, &V)>
     where
         T: Eq + PhfHash + ?Sized,
-        K: PhfBorrow<T>,
+        K: PhfEq<T>,
     {
         if self.disps.is_empty() {
             return None;
@@ -173,8 +173,7 @@ impl<K, V> Map<K, V> {
         let hashes = phf_shared::hash(key, &self.key);
         let index = phf_shared::get_index(&hashes, self.disps, self.entries.len());
         let entry = &self.entries[index as usize];
-        let b: &T = entry.0.borrow();
-        if b == key {
+        if entry.0.phf_eq(key) {
             Some((&entry.0, &entry.1))
         } else {
             None
@@ -186,7 +185,7 @@ impl<K, V> Map<K, V> {
     pub fn get_entry<T>(&self, key: &T) -> Option<(&K, &V)>
     where
         T: Eq + PhfHash + ?Sized,
-        K: PhfBorrow<T>,
+        K: PhfEq<T>,
     {
         if self.entries.is_empty() {
             return None;
@@ -201,9 +200,7 @@ impl<K, V> Map<K, V> {
             self.entries.len(),
         );
         let entry = &self.entries[index as usize];
-        let borrowed: &T = entry.0.borrow();
-
-        if borrowed == key {
+        if entry.0.phf_eq(key) {
             Some((&entry.0, &entry.1))
         } else {
             None

--- a/phf/src/ordered_map.rs
+++ b/phf/src/ordered_map.rs
@@ -4,7 +4,7 @@ use core::iter::FusedIterator;
 use core::iter::IntoIterator;
 use core::ops::Index;
 use core::slice;
-use phf_shared::{self, HashKey, PhfBorrow, PhfHash};
+use phf_shared::{self, HashKey, PhfEq, PhfHash};
 
 /// An order-preserving immutable map constructed at compile time.
 ///
@@ -65,7 +65,7 @@ where
 impl<'a, K, V, T: ?Sized> Index<&'a T> for OrderedMap<K, V>
 where
     T: Eq + PhfHash,
-    K: PhfBorrow<T>,
+    K: PhfEq<T>,
 {
     type Output = V;
 
@@ -121,7 +121,7 @@ impl<K, V> OrderedMap<K, V> {
     pub fn get<T>(&self, key: &T) -> Option<&V>
     where
         T: Eq + PhfHash + ?Sized,
-        K: PhfBorrow<T>,
+        K: PhfEq<T>,
     {
         self.get_entry(key).map(|e| e.1)
     }
@@ -133,7 +133,7 @@ impl<K, V> OrderedMap<K, V> {
     pub fn get_key<T>(&self, key: &T) -> Option<&K>
     where
         T: Eq + PhfHash + ?Sized,
-        K: PhfBorrow<T>,
+        K: PhfEq<T>,
     {
         self.get_entry(key).map(|e| e.0)
     }
@@ -142,7 +142,7 @@ impl<K, V> OrderedMap<K, V> {
     pub fn contains_key<T>(&self, key: &T) -> bool
     where
         T: Eq + PhfHash + ?Sized,
-        K: PhfBorrow<T>,
+        K: PhfEq<T>,
     {
         self.get(key).is_some()
     }
@@ -152,7 +152,7 @@ impl<K, V> OrderedMap<K, V> {
     pub fn get_index<T>(&self, key: &T) -> Option<usize>
     where
         T: Eq + PhfHash + ?Sized,
-        K: PhfBorrow<T>,
+        K: PhfEq<T>,
     {
         self.get_internal(key).map(|(i, _)| i)
     }
@@ -167,7 +167,7 @@ impl<K, V> OrderedMap<K, V> {
     pub fn get_entry<T>(&self, key: &T) -> Option<(&K, &V)>
     where
         T: Eq + PhfHash + ?Sized,
-        K: PhfBorrow<T>,
+        K: PhfEq<T>,
     {
         self.get_internal(key).map(|(_, e)| e)
     }
@@ -175,7 +175,7 @@ impl<K, V> OrderedMap<K, V> {
     fn get_internal<T>(&self, key: &T) -> Option<(usize, (&K, &V))>
     where
         T: Eq + PhfHash + ?Sized,
-        K: PhfBorrow<T>,
+        K: PhfEq<T>,
     {
         #[cfg(not(feature = "ptrhash"))]
         {
@@ -188,8 +188,7 @@ impl<K, V> OrderedMap<K, V> {
             let idx = self.idxs[idx_index as usize];
             let entry = &self.entries[idx];
 
-            let borrowed: &T = entry.0.borrow();
-            if borrowed == key {
+            if entry.0.phf_eq(key) {
                 Some((idx, (&entry.0, &entry.1)))
             } else {
                 None
@@ -213,8 +212,7 @@ impl<K, V> OrderedMap<K, V> {
             let idx = self.idxs[idx_index as usize];
             let entry = &self.entries[idx];
 
-            let borrowed: &T = entry.0.borrow();
-            if borrowed == key {
+            if entry.0.phf_eq(key) {
                 Some((idx, (&entry.0, &entry.1)))
             } else {
                 None

--- a/phf/src/ordered_set.rs
+++ b/phf/src/ordered_set.rs
@@ -3,7 +3,7 @@ use crate::{OrderedMap, PhfHash, ordered_map};
 use core::fmt;
 use core::iter::FusedIterator;
 use core::iter::IntoIterator;
-use phf_shared::PhfBorrow;
+use phf_shared::PhfEq;
 
 /// An order-preserving immutable set constructed at compile time.
 ///
@@ -60,7 +60,7 @@ impl<T> OrderedSet<T> {
     pub fn get_key<U>(&self, key: &U) -> Option<&T>
     where
         U: Eq + PhfHash + ?Sized,
-        T: PhfBorrow<U>,
+        T: PhfEq<U>,
     {
         self.map.get_key(key)
     }
@@ -70,7 +70,7 @@ impl<T> OrderedSet<T> {
     pub fn get_index<U>(&self, key: &U) -> Option<usize>
     where
         U: Eq + PhfHash + ?Sized,
-        T: PhfBorrow<U>,
+        T: PhfEq<U>,
     {
         self.map.get_index(key)
     }
@@ -85,7 +85,7 @@ impl<T> OrderedSet<T> {
     pub fn contains<U>(&self, value: &U) -> bool
     where
         U: Eq + PhfHash + ?Sized,
-        T: PhfBorrow<U>,
+        T: PhfEq<U>,
     {
         self.map.contains_key(value)
     }
@@ -102,7 +102,7 @@ impl<T> OrderedSet<T> {
 
 impl<T> OrderedSet<T>
 where
-    T: Eq + PhfHash + PhfBorrow<T>,
+    T: Eq + PhfHash + PhfEq<T>,
 {
     /// Returns true if `other` shares no elements with `self`.
     #[inline]

--- a/phf/src/set.rs
+++ b/phf/src/set.rs
@@ -3,7 +3,7 @@ use core::fmt;
 use core::iter::FusedIterator;
 use core::iter::IntoIterator;
 
-use phf_shared::{PhfBorrow, PhfHash};
+use phf_shared::{PhfEq, PhfHash};
 
 use crate::{Map, map};
 
@@ -59,7 +59,7 @@ impl<T> Set<T> {
     pub fn get_key<U>(&self, key: &U) -> Option<&T>
     where
         U: Eq + PhfHash + ?Sized,
-        T: PhfBorrow<U>,
+        T: PhfEq<U>,
     {
         self.map.get_key(key)
     }
@@ -68,7 +68,7 @@ impl<T> Set<T> {
     pub fn contains<U>(&self, value: &U) -> bool
     where
         U: Eq + PhfHash + ?Sized,
-        T: PhfBorrow<U>,
+        T: PhfEq<U>,
     {
         self.map.contains_key(value)
     }
@@ -85,7 +85,7 @@ impl<T> Set<T> {
 
 impl<T> Set<T>
 where
-    T: Eq + PhfHash + PhfBorrow<T>,
+    T: Eq + PhfHash + PhfEq<T>,
 {
     /// Returns true if `other` shares no elements with `self`.
     pub fn is_disjoint(&self, other: &Set<T>) -> bool {

--- a/phf_codegen/test/build.rs
+++ b/phf_codegen/test/build.rs
@@ -205,6 +205,26 @@ fn main() -> io::Result<()> {
             .build()
     )?;
 
+    writeln!(
+        &mut file,
+        "static ORDERED_TUPLE_MAP: ::phf::OrderedMap<(u32, &'static str), &'static str> = \n{};",
+        phf_codegen::OrderedMap::new()
+            .entry((1u32, "a"), "\"first\"")
+            .entry((2u32, "b"), "\"second\"")
+            .entry((3u32, "c"), "\"third\"")
+            .build()
+    )?;
+
+    writeln!(
+        &mut file,
+        "static ORDERED_TUPLE_SET: ::phf::OrderedSet<(u32, &'static str)> = \n{};",
+        phf_codegen::OrderedSet::new()
+            .entry((1u32, "x"))
+            .entry((2u32, "y"))
+            .entry((3u32, "z"))
+            .build()
+    )?;
+
     // Test nested tuple keys for Map
     writeln!(
         &mut file,

--- a/phf_codegen/test/src/lib.rs
+++ b/phf_codegen/test/src/lib.rs
@@ -178,6 +178,9 @@ mod test {
         assert_eq!("third", TUPLE_MAP[&(3u32, "c")]);
         assert!(!TUPLE_MAP.contains_key(&(4u32, "d")));
         assert!(!TUPLE_MAP.contains_key(&(1u32, "b")));
+
+        let key = String::from("a");
+        assert_eq!(Some(&"first"), TUPLE_MAP.get(&(1u32, key.as_str())));
     }
 
     #[test]
@@ -187,6 +190,33 @@ mod test {
         assert!(TUPLE_SET.contains(&(3u32, "z")));
         assert!(!TUPLE_SET.contains(&(4u32, "w")));
         assert!(!TUPLE_SET.contains(&(1u32, "y")));
+
+        let key = String::from("x");
+        assert!(TUPLE_SET.contains(&(1u32, key.as_str())));
+    }
+
+    #[test]
+    fn ordered_tuple_map() {
+        assert_eq!("first", ORDERED_TUPLE_MAP[&(1u32, "a")]);
+        assert_eq!("second", ORDERED_TUPLE_MAP[&(2u32, "b")]);
+        assert_eq!("third", ORDERED_TUPLE_MAP[&(3u32, "c")]);
+        assert!(!ORDERED_TUPLE_MAP.contains_key(&(4u32, "d")));
+        assert!(!ORDERED_TUPLE_MAP.contains_key(&(1u32, "b")));
+
+        let key = String::from("a");
+        assert_eq!(Some(&"first"), ORDERED_TUPLE_MAP.get(&(1u32, key.as_str())));
+    }
+
+    #[test]
+    fn ordered_tuple_set() {
+        assert!(ORDERED_TUPLE_SET.contains(&(1u32, "x")));
+        assert!(ORDERED_TUPLE_SET.contains(&(2u32, "y")));
+        assert!(ORDERED_TUPLE_SET.contains(&(3u32, "z")));
+        assert!(!ORDERED_TUPLE_SET.contains(&(4u32, "w")));
+        assert!(!ORDERED_TUPLE_SET.contains(&(1u32, "y")));
+
+        let key = String::from("x");
+        assert!(ORDERED_TUPLE_SET.contains(&(1u32, key.as_str())));
     }
 
     #[test]

--- a/phf_macros_test/tests/compile-fail/mixed.stderr
+++ b/phf_macros_test/tests/compile-fail/mixed.stderr
@@ -4,7 +4,7 @@ error: key type does not match the first key
 8 |     UniCase::ascii("FOO") => 1,
   |     ^^^^^^^^^^^^^^^^^^^^^
 
-error[E0277]: the trait bound `UniCase<&str>: phf_shared::PhfBorrow<_>` is not satisfied
+error[E0277]: the trait bound `UniCase<&str>: PhfEq<_>` is not satisfied
   --> tests/compile-fail/mixed.rs:12:18
    |
 12 |     KEYWORDS.get("foo").unwrap();
@@ -16,17 +16,18 @@ error[E0277]: the trait bound `UniCase<&str>: phf_shared::PhfBorrow<_>` is not s
              `&[T; N]` implements `phf_shared::PhfBorrow<[T; N]>`
              `&[T]` implements `phf_shared::PhfBorrow<[T]>`
              `&str` implements `phf_shared::PhfBorrow<str>`
-             `(A, B)` implements `phf_shared::PhfBorrow<(A, B)>`
-             `(A, B, C)` implements `phf_shared::PhfBorrow<(A, B, C)>`
-             `(A, B, C, D)` implements `phf_shared::PhfBorrow<(A, B, C, D)>`
-             `(A, B, C, D, E)` implements `phf_shared::PhfBorrow<(A, B, C, D, E)>`
-             `(A, B, C, D, E, F)` implements `phf_shared::PhfBorrow<(A, B, C, D, E, F)>`
+             `String` implements `phf_shared::PhfBorrow<str>`
+             `Vec<T>` implements `phf_shared::PhfBorrow<[T]>`
+             `[bool; N]` implements `phf_shared::PhfBorrow<[bool]>`
+             `[char; N]` implements `phf_shared::PhfBorrow<[char]>`
+             `[i128; N]` implements `phf_shared::PhfBorrow<[i128]>`
            and $N others
+   = note: required for `UniCase<&str>` to implement `PhfEq<_>`
 note: required by a bound in `phf::Map::<K, V>::get`
   --> $WORKSPACE/phf/src/map.rs
    |
    |     pub fn get<T>(&self, key: &T) -> Option<&V>
    |            --- required by a bound in this associated function
 ...
-   |         K: PhfBorrow<T>,
-   |            ^^^^^^^^^^^^ required by this bound in `Map::<K, V>::get`
+   |         K: PhfEq<T>,
+   |            ^^^^^^^^ required by this bound in `Map::<K, V>::get`

--- a/phf_macros_test/tests/test.rs
+++ b/phf_macros_test/tests/test.rs
@@ -359,6 +359,9 @@ mod map {
         assert_eq!(Some(&2), MAP.get(&(1u32, "b")));
         assert_eq!(Some(&3), MAP.get(&(2u32, "c")));
         assert_eq!(None, MAP.get(&(3u32, "d")));
+
+        let key = "a".to_string();
+        assert_eq!(Some(&1), MAP.get(&(0u32, key.as_str())));
     }
 
     #[test]
@@ -509,6 +512,9 @@ mod set {
         assert!(SET.contains(&(1u32, "b")));
         assert!(SET.contains(&(2u32, "c")));
         assert!(!SET.contains(&(3u32, "d")));
+
+        let key = "a".to_string();
+        assert!(SET.contains(&(0u32, key.as_str())));
     }
 
     #[test]
@@ -747,6 +753,9 @@ mod ordered_map {
         assert_eq!(Some(&2), MAP.get(&(1u32, "b")));
         assert_eq!(Some(&3), MAP.get(&(2u32, "c")));
         assert_eq!(None, MAP.get(&(3u32, "d")));
+
+        let key = "a".to_string();
+        assert_eq!(Some(&1), MAP.get(&(0u32, key.as_str())));
     }
 
     #[test]
@@ -932,6 +941,9 @@ mod ordered_set {
         assert!(SET.contains(&(1u32, "b")));
         assert!(SET.contains(&(2u32, "c")));
         assert!(!SET.contains(&(3u32, "d")));
+
+        let key = "a".to_string();
+        assert!(SET.contains(&(0u32, key.as_str())));
     }
 
     #[test]

--- a/phf_shared/src/lib.rs
+++ b/phf_shared/src/lib.rs
@@ -100,7 +100,8 @@ pub trait FmtConst {
 /// > In particular `Eq`, `Ord` and `Hash` must be equivalent for borrowed and owned values:
 /// > `x.borrow() == y.borrow()` should give the same result as `x == y`.
 ///
-/// (This crate's API only requires `Eq` and `PhfHash`, however.)
+/// (This crate's lookup API only requires `Eq`, `PhfHash`, and [`PhfEq`],
+/// however.)
 ///
 /// ### Motivation
 /// The conventional signature for lookup methods on collections looks something like this:
@@ -125,14 +126,36 @@ pub trait FmtConst {
 /// all the blanket impls.
 ///
 /// Instead, this trait is implemented conservatively, without blanket impls, so that impls like
-/// this may be added. This is feasible since the set of types that implement `PhfHash` is
-/// intentionally small.
+/// this may be added. [`PhfEq`] uses these impls for borrowed key forms that can be represented
+/// as a reference to the lookup key type. This is feasible since the set of types that implement
+/// `PhfHash` is intentionally small.
 ///
 /// This likely won't be fixable with specialization alone but will require full support for lattice
 /// impls since we technically want to add overlapping blanket impls.
 pub trait PhfBorrow<B: ?Sized> {
     /// Convert a reference to `self` to a reference to the borrowed type.
     fn borrow(&self) -> &B;
+}
+
+/// Trait for comparing stored PHF keys with runtime lookup keys.
+///
+/// Lookup keys must hash the same way as the stored key they compare equal to.
+/// Most borrowed key forms use the blanket implementation based on
+/// [`PhfBorrow`]. Tuples are implemented separately so references inside a
+/// tuple can use shorter lifetimes at lookup time. Tuple impls are provided up
+/// to 12 elements.
+pub trait PhfEq<B: ?Sized> {
+    /// Returns `true` if `self` and `other` are equivalent PHF keys.
+    fn phf_eq(&self, other: &B) -> bool;
+}
+
+impl<K, B: ?Sized + Eq> PhfEq<B> for K
+where
+    K: PhfBorrow<B>,
+{
+    fn phf_eq(&self, other: &B) -> bool {
+        self.borrow() == other
+    }
 }
 
 /// Create an impl of `FmtConst` delegating to `fmt::Debug` for types that can deal with it.
@@ -508,12 +531,6 @@ macro_rules! tuple_impl {
             }
         }
 
-        impl<$($t: PhfHash),+> PhfBorrow<($($t,)+)> for ($($t,)+) {
-            fn borrow(&self) -> &($($t,)+) {
-                self
-            }
-        }
-
         impl<$($t: FmtConst),+> FmtConst for ($($t,)+) {
             fn fmt_const(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 #[allow(non_snake_case)]
@@ -532,6 +549,21 @@ macro_rules! tuple_impl {
     };
 }
 
+macro_rules! tuple_eq_impl {
+    ($(($left_ty:ident, $left:ident, $right_ty:ident, $right:ident)),+) => {
+        impl<$($left_ty, $right_ty),+> PhfEq<($($right_ty,)+)> for ($($left_ty,)+)
+        where
+            $($left_ty: PartialEq<$right_ty>),+
+        {
+            fn phf_eq(&self, other: &($($right_ty,)+)) -> bool {
+                let ($($left,)+) = self;
+                let ($($right,)+) = other;
+                true $(&& $left == $right)+
+            }
+        }
+    };
+}
+
 tuple_impl!(A);
 tuple_impl!(A, B);
 tuple_impl!(A, B, C);
@@ -544,6 +576,100 @@ tuple_impl!(A, B, C, D, E, F, G, HT, I);
 tuple_impl!(A, B, C, D, E, F, G, HT, I, J);
 tuple_impl!(A, B, C, D, E, F, G, HT, I, J, K);
 tuple_impl!(A, B, C, D, E, F, G, HT, I, J, K, L);
+
+tuple_eq_impl!((A, a, AT, at));
+tuple_eq_impl!((A, a, AT, at), (B, b, BT, bt));
+tuple_eq_impl!((A, a, AT, at), (B, b, BT, bt), (C, c, CT, ct));
+tuple_eq_impl!(
+    (A, a, AT, at),
+    (B, b, BT, bt),
+    (C, c, CT, ct),
+    (D, d, DT, dt)
+);
+tuple_eq_impl!(
+    (A, a, AT, at),
+    (B, b, BT, bt),
+    (C, c, CT, ct),
+    (D, d, DT, dt),
+    (E, e, ET, et)
+);
+tuple_eq_impl!(
+    (A, a, AT, at),
+    (B, b, BT, bt),
+    (C, c, CT, ct),
+    (D, d, DT, dt),
+    (E, e, ET, et),
+    (F, ff, FT, ft)
+);
+tuple_eq_impl!(
+    (A, a, AT, at),
+    (B, b, BT, bt),
+    (C, c, CT, ct),
+    (D, d, DT, dt),
+    (E, e, ET, et),
+    (F, ff, FT, ft),
+    (G, g, GT, gt)
+);
+tuple_eq_impl!(
+    (A, a, AT, at),
+    (B, b, BT, bt),
+    (C, c, CT, ct),
+    (D, d, DT, dt),
+    (E, e, ET, et),
+    (F, ff, FT, ft),
+    (G, g, GT, gt),
+    (H, h, HT, ht)
+);
+tuple_eq_impl!(
+    (A, a, AT, at),
+    (B, b, BT, bt),
+    (C, c, CT, ct),
+    (D, d, DT, dt),
+    (E, e, ET, et),
+    (F, ff, FT, ft),
+    (G, g, GT, gt),
+    (H, h, HT, ht),
+    (I, i, IT, it)
+);
+tuple_eq_impl!(
+    (A, a, AT, at),
+    (B, b, BT, bt),
+    (C, c, CT, ct),
+    (D, d, DT, dt),
+    (E, e, ET, et),
+    (F, ff, FT, ft),
+    (G, g, GT, gt),
+    (H, h, HT, ht),
+    (I, i, IT, it),
+    (J, j, JT, jt)
+);
+tuple_eq_impl!(
+    (A, a, AT, at),
+    (B, b, BT, bt),
+    (C, c, CT, ct),
+    (D, d, DT, dt),
+    (E, e, ET, et),
+    (F, ff, FT, ft),
+    (G, g, GT, gt),
+    (H, h, HT, ht),
+    (I, i, IT, it),
+    (J, j, JT, jt),
+    (K, k, KT, kt)
+);
+tuple_eq_impl!(
+    (A, a, AT, at),
+    (B, b, BT, bt),
+    (C, c, CT, ct),
+    (D, d, DT, dt),
+    (E, e, ET, et),
+    (F, ff, FT, ft),
+    (G, g, GT, gt),
+    (H, h, HT, ht),
+    (I, i, IT, it),
+    (J, j, JT, jt),
+    (K, k, KT, kt),
+    (L, l, LT, lt)
+);
 
 #[cfg(test)]
 mod tests {
@@ -656,6 +782,28 @@ mod tests {
         assert_borrow::<&[u32; 2], [u32; 2]>();
         assert_borrow::<&[bool; 2], [bool; 2]>();
         assert_borrow::<&[char; 2], [char; 2]>();
+    }
+
+    #[test]
+    fn tuple_eq_allows_shorter_reference_lifetimes() {
+        fn assert_ref_tuple<'a>(key: &(&'a str, &'a str)) -> bool
+        where
+            (&'static str, &'static str): PhfEq<(&'a str, &'a str)>,
+        {
+            ("a", "b").phf_eq(key)
+        }
+
+        fn assert_mixed_tuple<'a>(key: &(u32, &'a str)) -> bool
+        where
+            (u32, &'static str): PhfEq<(u32, &'a str)>,
+        {
+            (1, "a").phf_eq(key)
+        }
+
+        let a = String::from("a");
+        let b = String::from("b");
+        assert!(assert_ref_tuple(&(a.as_str(), b.as_str())));
+        assert!(assert_mixed_tuple(&(1, a.as_str())));
     }
 
     #[test]


### PR DESCRIPTION
Fix #352, fix #359

`PhfBorrow` doesn't work for tuples. Instead, this implements `PhfEq` and PartialEq so that tuples can be used without the lifetime issue.