### PR TITLE
perf: eliminate division

### DIFF
--- a/phf_generator/src/lib.rs
+++ b/phf_generator/src/lib.rs
@@ -172,7 +172,8 @@ impl Generator {
                     for &key in keys {
                         let disp =
                             phf_shared::displace(self.hashes[key].f1, self.hashes[key].f2, d1, d2);
-                        let idx = (((disp as u64) * (table_len as u64)) >> 32) as usize;
+                        let idx = (((disp.wrapping_mul(0x9e3779b9) as u64) * (table_len as u64)) >> 32)
+                            as usize;
                         if self.map[idx] != EMPTY_SLOT || self.try_map[idx] == generation {
                             continue 'disps;
                         }

--- a/phf_generator/src/lib.rs
+++ b/phf_generator/src/lib.rs
@@ -121,7 +121,7 @@ impl Generator {
 
         // Store bucket contents in one flat buffer instead of allocating a Vec per bucket.
         for (i, hash) in self.hashes.iter().enumerate() {
-            let bucket = (hash.g % buckets_len) as usize;
+            let bucket = (((hash.g as u64) * (buckets_len as u64)) >> 32) as usize;
             self.key_buckets[i] = bucket;
             let bucket = &mut self.buckets[bucket];
             bucket.len += 1;
@@ -170,9 +170,9 @@ impl Generator {
                     generation += 1;
 
                     for &key in keys {
-                        let idx =
-                            (phf_shared::displace(self.hashes[key].f1, self.hashes[key].f2, d1, d2)
-                                % (table_len as u32)) as usize;
+                        let disp =
+                            phf_shared::displace(self.hashes[key].f1, self.hashes[key].f2, d1, d2);
+                        let idx = (((disp as u64) * (table_len as u64)) >> 32) as usize;
                         if self.map[idx] != EMPTY_SLOT || self.try_map[idx] == generation {
                             continue 'disps;
                         }

--- a/phf_generator/src/lib.rs
+++ b/phf_generator/src/lib.rs
@@ -172,8 +172,8 @@ impl Generator {
                     for &key in keys {
                         let disp =
                             phf_shared::displace(self.hashes[key].f1, self.hashes[key].f2, d1, d2);
-                        let idx = (((disp.wrapping_mul(0x9e3779b9) as u64) * (table_len as u64)) >> 32)
-                            as usize;
+                        let idx = (((disp.wrapping_mul(0x9e3779b9) as u64) * (table_len as u64))
+                            >> 32) as usize;
                         if self.map[idx] != EMPTY_SLOT || self.try_map[idx] == generation {
                             continue 'disps;
                         }

--- a/phf_shared/src/lib.rs
+++ b/phf_shared/src/lib.rs
@@ -64,7 +64,7 @@ pub fn get_index(hashes: &Hashes, disps: &[(u32, u32)], len: usize) -> u32 {
     let bucket = (((hashes.g as u64) * (disps.len() as u64)) >> 32) as usize;
     let (d1, d2) = disps[bucket];
     let disp = displace(hashes.f1, hashes.f2, d1, d2);
-    (((disp as u64) * (len as u64)) >> 32) as u32
+    (((disp.wrapping_mul(0x9e3779b9) as u64) * (len as u64)) >> 32) as u32
 }
 
 /// A trait implemented by types which can be used in PHF data structures.

--- a/phf_shared/src/lib.rs
+++ b/phf_shared/src/lib.rs
@@ -61,8 +61,10 @@ pub fn hash<T: ?Sized + PhfHash>(x: &T, key: &HashKey) -> Hashes {
 /// * `len` is the length of `phf_generator::HashState::map`.
 #[inline]
 pub fn get_index(hashes: &Hashes, disps: &[(u32, u32)], len: usize) -> u32 {
-    let (d1, d2) = disps[(hashes.g % (disps.len() as u32)) as usize];
-    displace(hashes.f1, hashes.f2, d1, d2) % (len as u32)
+    let bucket = (((hashes.g as u64) * (disps.len() as u64)) >> 32) as usize;
+    let (d1, d2) = disps[bucket];
+    let disp = displace(hashes.f1, hashes.f2, d1, d2);
+    (((disp as u64) * (len as u64)) >> 32) as u32
 }
 
 /// A trait implemented by types which can be used in PHF data structures.


### PR DESCRIPTION
## Motivation

The size of a perfect hash map and its displacement table are known at compile time. This means that both the map
length and the bucket/displacement length are effectively constant. Ideally, the Rust compiler would specialize the
modulo (`%`) division into a cheaper combination of multiplication and shifts. 

Indeed, if `phf::Map` was parameterized via const generics (e.g., `const BUCKETS: usize`), the compiler could
perform this specialization automatically (see https://godbolt.org/z/c8hhGq4hM). However, doing so would break the
public API and backward compatibility. Therefore, we must perform this range reduction optimization manually.

## Optimization

We replace the hardware-expensive `%` (division-based modulo) operations with Daniel Lemire's fast range reduction
algorithm (see https://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/).

### Addressing the Low-Entropy Collision Bottleneck

Lemire's algorithm maps a hash $x \in [0, 2^{32})$ to a range $[0, N)$ using the formula:
$$\text{idx} = \frac{x \times N}{2^{32}}$$

Because this maps a contiguous block of size $2^{32}/N$ to the same index, consecutive inputs tend to map to the
same bucket. More importantly, during CHD (Compress, Hash, Displace) generation, the solver incrementally varies the
displacement seed $d2$ (yielding $d2, d2+1, \dots$). Since $d2$ is small, the displacement hash `disp = d2 ^ C` only
varies in its lower bits, keeping the upper bits constant. Under Lemire's scaling, this lack of high-bit entropy
causes different displacement seeds to map to the exact same index slot, trapping the solver in a high-collision loop
and causing compilation time to regress significantly.

To resolve this, we multiply the displacement hash by `0x9e3779b9` (an odd prime multiplier based on the golden
ratio) before applying Lemire's reduction. This performs bijective multiplicative hashing, scattering the low-bit
variations of $d2$ across all 32 bits and ensuring uniform distribution.

Both compile-time map construction (`phf_generator`) and runtime query lookups (`phf_shared`) benefit from this
improvement.

## Test and Perf

A cross-platform benchmark workflow runs on PRs. Here are the [workflow run](https://github.
com/hsqStephenZhang/rust-phf/actions/runs/31162480176/job/92815742341) and the [compiled benchmark
results](https://github.com/hsqStephenZhang/rust-phf/actions/runs/31162480186). The results show a stable and
remarkable improvement across all size classes and key types.

I also ran benchmarks on real-world downstream projects like [typos](https://github.com/crate-ci/typos) (which
generates a 95k-word dictionary map). The perfect hash map construction speed improved by over 30%, and the runtime
queries (especially misses) are also faster. I can set up a standalone benchmark repository to share detailed results
if requested.

## LLM usage disclosure

The benchmark is greatly assisted by gemini.